### PR TITLE
Fix warning of Pytorch-1.6

### DIFF
--- a/mmdet3d/core/bbox/samplers/iou_neg_piecewise_sampler.py
+++ b/mmdet3d/core/bbox/samplers/iou_neg_piecewise_sampler.py
@@ -55,7 +55,7 @@ class IoUNegPiecewiseSampler(RandomSampler):
 
     def _sample_neg(self, assign_result, num_expected, **kwargs):
         """Randomly sample some negative samples."""
-        neg_inds = torch.nonzero(assign_result.gt_inds == 0)
+        neg_inds = torch.nonzero(assign_result.gt_inds == 0, as_tuple=False)
         if neg_inds.numel() != 0:
             neg_inds = neg_inds.squeeze(1)
         if len(neg_inds) <= num_expected:
@@ -80,7 +80,8 @@ class IoUNegPiecewiseSampler(RandomSampler):
                 max_iou_thr = self.neg_iou_thr[piece_inds]
                 piece_neg_inds = torch.nonzero(
                     (max_overlaps >= min_iou_thr)
-                    & (max_overlaps < max_iou_thr)).view(-1)
+                    & (max_overlaps < max_iou_thr),
+                    as_tuple=False).view(-1)
 
                 if len(piece_neg_inds) < piece_expected_num:
                     neg_inds_choice = torch.cat(

--- a/mmdet3d/core/post_processing/box3d_nms.py
+++ b/mmdet3d/core/post_processing/box3d_nms.py
@@ -129,7 +129,8 @@ def aligned_3d_nms(boxes, scores, classes, thresh):
         inter = inter_l * inter_w * inter_h
         iou = inter / (area[i] + area[score_sorted[:last - 1]] - inter)
         iou = iou * (classes1 == classes2).float()
-        score_sorted = score_sorted[torch.nonzero(iou <= thresh).flatten()]
+        score_sorted = score_sorted[torch.nonzero(
+            iou <= thresh, as_tuple=False).flatten()]
 
     indices = boxes.new_tensor(pick, dtype=torch.long)
     return indices

--- a/mmdet3d/models/dense_heads/free_anchor3d_head.py
+++ b/mmdet3d/models/dense_heads/free_anchor3d_head.py
@@ -140,7 +140,7 @@ class FreeAnchor3DHead(Anchor3DHead):
                 box_cls_prob = torch.sparse.sum(
                     object_cls_box_prob, dim=0).to_dense()
 
-                indices = torch.nonzero(box_cls_prob).t_()
+                indices = torch.nonzero(box_cls_prob, as_tuple=False).t_()
                 if indices.numel() == 0:
                     image_box_prob = torch.zeros(
                         anchors_.size(0),

--- a/mmdet3d/models/dense_heads/vote_head.py
+++ b/mmdet3d/models/dense_heads/vote_head.py
@@ -409,7 +409,8 @@ class VoteHead(nn.Module):
             box_indices_all = gt_bboxes_3d.points_in_boxes(points)
             for i in range(gt_labels_3d.shape[0]):
                 box_indices = box_indices_all[:, i]
-                indices = torch.nonzero(box_indices).squeeze(-1)
+                indices = torch.nonzero(
+                    box_indices, as_tuple=False).squeeze(-1)
                 selected_points = points[indices]
                 vote_target_masks[indices] = 1
                 vote_targets_tmp = vote_targets[indices]
@@ -418,7 +419,8 @@ class VoteHead(nn.Module):
 
                 for j in range(self.gt_per_seed):
                     column_indices = torch.nonzero(
-                        vote_target_idx[indices] == j).squeeze(-1)
+                        vote_target_idx[indices] == j,
+                        as_tuple=False).squeeze(-1)
                     vote_targets_tmp[column_indices,
                                      int(j * 3):int(j * 3 +
                                                     3)] = votes[column_indices]
@@ -435,7 +437,8 @@ class VoteHead(nn.Module):
                                                  dtype=torch.long)
 
             for i in torch.unique(pts_instance_mask):
-                indices = torch.nonzero(pts_instance_mask == i).squeeze(-1)
+                indices = torch.nonzero(
+                    pts_instance_mask == i, as_tuple=False).squeeze(-1)
                 if pts_semantic_mask[indices[0]] < self.num_classes:
                     selected_points = points[indices, :3]
                     center = 0.5 * (
@@ -558,7 +561,8 @@ class VoteHead(nn.Module):
 
         # filter empty boxes and boxes with low score
         scores_mask = (obj_scores > self.test_cfg.score_thr)
-        nonempty_box_inds = torch.nonzero(nonempty_box_mask).flatten()
+        nonempty_box_inds = torch.nonzero(
+            nonempty_box_mask, as_tuple=False).flatten()
         nonempty_mask = torch.zeros_like(bbox_classes).scatter(
             0, nonempty_box_inds[nms_selected], 1)
         selected = (nonempty_mask.bool() & scores_mask.bool())

--- a/mmdet3d/ops/iou3d/iou3d_utils.py
+++ b/mmdet3d/ops/iou3d/iou3d_utils.py
@@ -37,7 +37,7 @@ def nms_gpu(boxes, scores, thresh):
 
     boxes = boxes[order].contiguous()
 
-    keep = boxes.new_zeros(boxes.size(0))
+    keep = torch.zeros(boxes.size(0), dtype=torch.long)
     num_out = iou3d_cuda.nms_gpu(boxes, keep, thresh, boxes.device.index)
     return order[keep[:num_out].cuda(boxes.device)].contiguous()
 
@@ -57,7 +57,7 @@ def nms_normal_gpu(boxes, scores, thresh):
 
     boxes = boxes[order].contiguous()
 
-    keep = boxes.new_zeros(boxes.size(0))
+    keep = torch.zeros(boxes.size(0), dtype=torch.long)
     num_out = iou3d_cuda.nms_normal_gpu(boxes, keep, thresh,
                                         boxes.device.index)
     return order[keep[:num_out].cuda(boxes.device)].contiguous()


### PR DESCRIPTION
This PR fixes some warnings when using Pytorch-1.6. It adds `as_tuple=False` when using `torch.nonzero`.

It also fixes the bug of NMS introduced by https://github.com/open-mmlab/mmdetection3d/pull/69.