### PR TITLE
Fixes LoadMultiViewImageFromFiles

### DIFF
--- a/mmdet3d/datasets/pipelines/formating.py
+++ b/mmdet3d/datasets/pipelines/formating.py
@@ -47,7 +47,10 @@ class DefaultFormatBundle(object):
                 imgs = np.ascontiguousarray(np.stack(imgs, axis=0))
                 results['img'] = DC(to_tensor(imgs), stack=True)
             else:
-                img = np.ascontiguousarray(results['img'].transpose(2, 0, 1))
+                # move rgb dimension to front
+                # (h x w x rgb x multi_imgs) -> (rgb x h x w x rgb x multi_imgs)
+                # last dim is  optional
+                img = np.ascontiguousarray(np.moveaxis(results['img'], 2, 0))
                 results['img'] = DC(to_tensor(img), stack=True)
         for key in [
                 'proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels',

--- a/mmdet3d/datasets/pipelines/formating.py
+++ b/mmdet3d/datasets/pipelines/formating.py
@@ -48,7 +48,8 @@ class DefaultFormatBundle(object):
                 results['img'] = DC(to_tensor(imgs), stack=True)
             else:
                 # move rgb dimension to front
-                # (h x w x rgb x multi_imgs) -> (rgb x h x w x rgb x multi_imgs)
+                # (h x w x rgb x multi_imgs)
+                # to (rgb x h x w x rgb x multi_imgs)
                 # last dim is  optional
                 img = np.ascontiguousarray(np.moveaxis(results['img'], 2, 0))
                 results['img'] = DC(to_tensor(img), stack=True)


### PR DESCRIPTION
Fixes a bug that prevents the use of LoadMultiViewImageFromFiles in data loading pipelines, see #227 for a bug report.
Is the new order of ```img = (rgb x h x w x rgb x multi_imgs)``` the desired one?
Any help is appreciated, I'm quite new to the framework. 