### PR TITLE
Fixed issue unpacking size in furthest_point_sample

### DIFF
--- a/mmdet3d/ops/furthest_point_sample/furthest_point_sample.py
+++ b/mmdet3d/ops/furthest_point_sample/furthest_point_sample.py
@@ -25,7 +25,7 @@ class FurthestPointSampling(Function):
         """
         assert points_xyz.is_contiguous()
 
-        B, N, _ = points_xyz.size()
+        B, N = points_xyz.size()[:2]
         output = torch.cuda.IntTensor(B, num_points)
         temp = torch.cuda.FloatTensor(B, N).fill_(1e10)
 


### PR DESCRIPTION
When running the VoteNet demo on sunrgbd with:

```
python tools/test.py configs/votenet/votenet_16x8_sunrgbd-3d-10class.py checkpoints/votenet_16x8_sunrgbd-3d-10class_20200620_230238-4483c0c0.pth --show --show-dir ./data/votenet/show_results
```

I got an error in `mmdetection3d/mmdet3d/ops/furthest_point_sample/furthest_point_sample.py` because `points_xyz` was a tuple of size 4, but it was being unpacked into a tuple of size 3. I changed:
```
B, N, _ = points_xyz.size()
```
to
```
B, N = points_xyz.size()[:2]
```
and now everything works correctly. 