### PR TITLE
fix bug caused by mmcv upgrade; delete pdb breakpoint

### DIFF
--- a/mmdet3d/models/detectors/centerpoint.py
+++ b/mmdet3d/models/detectors/centerpoint.py
@@ -181,8 +181,6 @@ class CenterPoint(MVXTwoStageDetector):
         else:
             for key in bbox_list[0].keys():
                 bbox_list[0][key] = bbox_list[0][key].to('cpu')
-            import pdb
-            pdb.set_trace()
             return bbox_list[0]
 
     def aug_test(self, points, img_metas, imgs=None, rescale=False):

--- a/tests/test_models/test_heads/test_heads.py
+++ b/tests/test_models/test_heads/test_heads.py
@@ -815,7 +815,7 @@ def test_dcn_center_head():
                 kernel_size=3,
                 padding=1,
                 groups=4,
-                bias=True),
+                bias=False),  # mmcv 1.2.6 doesn't support bias=True anymore
             init_bias=-2.19,
             final_kernel=3),
         loss_cls=dict(type='GaussianFocalLoss', reduction='mean'),


### PR DESCRIPTION
Fixed bias=True bug triggered when using mmcv==1.2.6;
Deleted pdb breakpoint.