### PR TITLE
fix nonzero warning with as_tuple, fix requirements for open3d

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Welcome to MMDetection3D's documentation!
    getting_started.md
    model_zoo.md
    data_preparation.md
-   
+
 .. toctree::
    :maxdepth: 2
    :caption: Quick Run

--- a/mmdet3d/models/dense_heads/anchor3d_head.py
+++ b/mmdet3d/models/dense_heads/anchor3d_head.py
@@ -225,7 +225,8 @@ class Anchor3DHead(nn.Module, AnchorTrainMixin):
 
         bg_class_ind = self.num_classes
         pos_inds = ((labels >= 0)
-                    & (labels < bg_class_ind)).nonzero(as_tuple=False).reshape(-1)
+                    & (labels < bg_class_ind)).nonzero(
+                        as_tuple=False).reshape(-1)
         num_pos = len(pos_inds)
 
         pos_bbox_pred = bbox_pred[pos_inds]

--- a/mmdet3d/models/dense_heads/anchor3d_head.py
+++ b/mmdet3d/models/dense_heads/anchor3d_head.py
@@ -225,7 +225,7 @@ class Anchor3DHead(nn.Module, AnchorTrainMixin):
 
         bg_class_ind = self.num_classes
         pos_inds = ((labels >= 0)
-                    & (labels < bg_class_ind)).nonzero().reshape(-1)
+                    & (labels < bg_class_ind)).nonzero(as_tuple=False).reshape(-1)
         num_pos = len(pos_inds)
 
         pos_bbox_pred = bbox_pred[pos_inds]

--- a/mmdet3d/models/dense_heads/ssd_3d_head.py
+++ b/mmdet3d/models/dense_heads/ssd_3d_head.py
@@ -519,7 +519,8 @@ class SSD3DHead(VoteHead):
 
         # filter empty boxes and boxes with low score
         scores_mask = (obj_scores >= self.test_cfg.score_thr)
-        nonempty_box_inds = torch.nonzero(nonempty_box_mask, as_tuple=False).flatten()
+        nonempty_box_inds = torch.nonzero(
+            nonempty_box_mask, as_tuple=False).flatten()
         nonempty_mask = torch.zeros_like(bbox_classes).scatter(
             0, nonempty_box_inds[nms_selected], 1)
         selected = (nonempty_mask.bool() & scores_mask.bool())

--- a/mmdet3d/models/dense_heads/ssd_3d_head.py
+++ b/mmdet3d/models/dense_heads/ssd_3d_head.py
@@ -519,7 +519,7 @@ class SSD3DHead(VoteHead):
 
         # filter empty boxes and boxes with low score
         scores_mask = (obj_scores >= self.test_cfg.score_thr)
-        nonempty_box_inds = torch.nonzero(nonempty_box_mask).flatten()
+        nonempty_box_inds = torch.nonzero(nonempty_box_mask, as_tuple=False).flatten()
         nonempty_mask = torch.zeros_like(bbox_classes).scatter(
             0, nonempty_box_inds[nms_selected], 1)
         selected = (nonempty_mask.bool() & scores_mask.bool())

--- a/mmdet3d/models/dense_heads/train_mixins.py
+++ b/mmdet3d/models/dense_heads/train_mixins.py
@@ -277,11 +277,11 @@ class AnchorTrainMixin(object):
             neg_inds = sampling_result.neg_inds
         else:
             pos_inds = torch.nonzero(
-                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) > 0, as_tuple=False
-            ).squeeze(-1).unique()
+                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) > 0,
+                as_tuple=False).squeeze(-1).unique()
             neg_inds = torch.nonzero(
-                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) == 0, as_tuple=False
-            ).squeeze(-1).unique()
+                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) == 0,
+                as_tuple=False).squeeze(-1).unique()
 
         if gt_labels is not None:
             labels += num_classes

--- a/mmdet3d/models/dense_heads/train_mixins.py
+++ b/mmdet3d/models/dense_heads/train_mixins.py
@@ -277,11 +277,11 @@ class AnchorTrainMixin(object):
             neg_inds = sampling_result.neg_inds
         else:
             pos_inds = torch.nonzero(
-                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) > 0
+                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) > 0, as_tuple=False
             ).squeeze(-1).unique()
             neg_inds = torch.nonzero(
-                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) ==
-                0).squeeze(-1).unique()
+                anchors.new_zeros((anchors.shape[0], ), dtype=torch.bool) == 0, as_tuple=False
+            ).squeeze(-1).unique()
 
         if gt_labels is not None:
             labels += num_classes

--- a/mmdet3d/models/roi_heads/bbox_heads/h3d_bbox_head.py
+++ b/mmdet3d/models/roi_heads/bbox_heads/h3d_bbox_head.py
@@ -525,7 +525,7 @@ class H3DBboxHead(nn.Module):
 
         # filter empty boxes and boxes with low score
         scores_mask = (obj_scores > self.test_cfg.score_thr)
-        nonempty_box_inds = torch.nonzero(nonempty_box_mask).flatten()
+        nonempty_box_inds = torch.nonzero(nonempty_box_mask, as_tuple=False).flatten()
         nonempty_mask = torch.zeros_like(bbox_classes).scatter(
             0, nonempty_box_inds[nms_selected], 1)
         selected = (nonempty_mask.bool() & scores_mask.bool())

--- a/mmdet3d/models/roi_heads/bbox_heads/h3d_bbox_head.py
+++ b/mmdet3d/models/roi_heads/bbox_heads/h3d_bbox_head.py
@@ -525,7 +525,8 @@ class H3DBboxHead(nn.Module):
 
         # filter empty boxes and boxes with low score
         scores_mask = (obj_scores > self.test_cfg.score_thr)
-        nonempty_box_inds = torch.nonzero(nonempty_box_mask, as_tuple=False).flatten()
+        nonempty_box_inds = torch.nonzero(
+            nonempty_box_mask, as_tuple=False).flatten()
         nonempty_mask = torch.zeros_like(bbox_classes).scatter(
             0, nonempty_box_inds[nms_selected], 1)
         selected = (nonempty_mask.bool() & scores_mask.bool())

--- a/mmdet3d/models/roi_heads/mask_heads/primitive_head.py
+++ b/mmdet3d/models/roi_heads/mask_heads/primitive_head.py
@@ -369,7 +369,7 @@ class PrimitiveHead(nn.Module):
                 pts_instance_mask[background_mask] = gt_labels_3d.shape[0]
 
         instance_flag = torch.nonzero(
-            pts_semantic_mask != self.num_classes).squeeze(1)
+            pts_semantic_mask != self.num_classes, as_tuple=False).squeeze(1)
         instance_labels = pts_instance_mask[instance_flag].unique()
 
         with_yaw = gt_bboxes_3d.with_yaw

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,3 @@
 open3d==0.9.0.0
+# The latest open3d need the support of file 'GLIBC_2.27', which only exist in Ubuntu 18.04, not in Ubuntu 16.04
 waymo-open-dataset-tf-2-1-0==1.2.0

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,2 @@
-open3d
+open3d==0.9.0.0
 waymo-open-dataset-tf-2-1-0==1.2.0


### PR DESCRIPTION
[Fix]: Fix warning of deprecated usages of nonzero during training with pytorch 1.6 (#320 )

* fix warning caused by upgrade of pytorch with specifying as_tuple=Fasle

[Fix]: Fix import error after installing latest open3d

* latest open3d only work in Ubuntu 18.04 because of the lack of GLIBC_2.27 in Ubuntu 16.04