### PR TITLE
[Fix] fix SECOND Waymo results

### DIFF
--- a/configs/second/README.md
+++ b/configs/second/README.md
@@ -27,9 +27,9 @@ We implement SECOND and provide the results and checkpoints on KITTI dataset.
 
 |  Backbone | Load Interval | Class | Lr schd | Mem (GB) | Inf time (fps) | mAP@L1 | mAPH@L1 |  mAP@L2 | **mAPH@L2** | Download |
 | :-------: | :-----------: |:-----:| :------:| :------: | :------------: | :----: | :-----: | :-----: | :-----: | :------: |
-| [SECFPN](./hv_second_secfpn_sbn_2x16_2x_waymoD5-3d-3class.py)|5|3 Class|2x|8.12||58.0|53.5|51.5|48.3|[log](https://download.openmmlab.com/mmdetection3d/v0.1.0_models/second/hv_second_secfpn_sbn_4x8_2x_waymoD5-3d-3class/hv_second_secfpn_sbn_4x8_2x_waymoD5-3d-3class_20201115_112448.log.json)|
-| above @ Car|||2x|8.12||58.5|57.9|51.6|51.1| |
-| above @ Pedestrian|||2x|8.12||63.9|54.9|56.0|48.0| |
-| above @ Cyclist|||2x|8.12||48.6|47.6|46.8|45.8| |
+| [SECFPN](./hv_second_secfpn_sbn_2x16_2x_waymoD5-3d-3class.py)|5|3 Class|2x|8.12||65.3|61.7|58.9|55.7|[log](https://download.openmmlab.com/mmdetection3d/v0.1.0_models/second/hv_second_secfpn_sbn_4x8_2x_waymoD5-3d-3class/hv_second_secfpn_sbn_4x8_2x_waymoD5-3d-3class_20201115_112448.log.json)|
+| above @ Car|||2x|8.12||67.1|66.6|58.7|58.2| |
+| above @ Pedestrian|||2x|8.12||68.1|59.1|59.5|51.5| |
+| above @ Cyclist|||2x|8.12||60.7|59.5|58.4|57.3| |
 
 Note: See more details about metrics and data split on Waymo [HERE](https://github.com/open-mmlab/mmdetection3d/tree/master/configs/pointpillars). For implementation details, we basically follow the original settings. All of these results are achieved without bells-and-whistles, e.g. ensemble, multi-scale training and test augmentation.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -92,7 +92,7 @@
 
 #### Improvements
 
-- Enhance [SECOND](https://github.com/open-mmlab/mmdetection3d/tree/master/configs/second) benchmark on Waymo with stronger baselines. (#166)
+- Enhance [SECOND](https://github.com/open-mmlab/mmdetection3d/tree/master/configs/second) benchmark on Waymo with stronger baselines. (#205)
 - Add model zoo statistics and polish the documentation. (#201)
 
 ### v0.7.0 (1/11/2020)


### PR DESCRIPTION
The results of SECOND on Waymo do not match the log file. The results on README are too low.

README:
| [SECFPN]|5|3 Class|2x|8.12||58.0|53.5|51.5|48.3|log|
| above @ Car|||2x|8.12||58.5|57.9|51.6|51.1| |
| above @ Pedestrian|||2x|8.12||63.9|54.9|56.0|48.0| |
| above @ Cyclist|||2x|8.12||48.6|47.6|46.8|45.8| |

LOG:
{"mode": "val", "epoch": 24, "iter": 1977, "lr": 1e-05, "Vehicle/L1 mAP": 0.67149, "Vehicle/L1 mAPH": 0.66598, "Vehicle/L2 mAP": 0.58660, "Vehicle/L2 mAPH": 0.58173, "Pedestrian/L1 mAP": 0.68099, "Pedestrian/L1 mAPH": 0.59131, "Pedestrian/L2 mAP": 0.59516, "Pedestrian/L2 mAPH": 0.51546, "Sign/L1 mAP": 0.0, "Sign/L1 mAPH": 0.0, "Sign/L2 mAP": 0.0, "Sign/L2 mAPH": 0.0, "Cyclist/L1 mAP": 0.60655, "Cyclist/L1 mAPH": 0.59519, "Cyclist/L2 mAP": 0.58416, "Cyclist/L2 mAPH": 0.57321, "Overall/L1 mAP": 0.65301, "Overall/L1 mAPH": 0.61749, "Overall/L2 mAP": 0.58864, "Overall/L2 mAPH": 0.55680}