### PR TITLE
[Fix] Fix a bug when adding ('val', 1) to workflow

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -179,11 +179,11 @@ def main():
     datasets = [build_dataset(cfg.data.train)]
     if len(cfg.workflow) == 2:
         val_dataset = copy.deepcopy(cfg.data.val)
-        try:
-            val_dataset.pipeline = cfg.data.train.pipeline
         # in case we use a dataset wrapper
-        except AttributeError:
+        if 'dataset' in cfg.data.train:
             val_dataset.pipeline = cfg.data.train.dataset.pipeline
+        else:
+            val_dataset.pipeline = cfg.data.train.pipeline
         # set test_mode=False here in deep copied config
         # which do not affect AP/AR calculation later
         # refer to https://mmdetection3d.readthedocs.io/en/latest/tutorials/customize_runtime.html#customize-workflow  # noqa

--- a/tools/train.py
+++ b/tools/train.py
@@ -179,7 +179,15 @@ def main():
     datasets = [build_dataset(cfg.data.train)]
     if len(cfg.workflow) == 2:
         val_dataset = copy.deepcopy(cfg.data.val)
-        val_dataset.pipeline = cfg.data.train.pipeline
+        try:
+            val_dataset.pipeline = cfg.data.train.pipeline
+        # in case we use a dataset wrapper
+        except AttributeError:
+            val_dataset.pipeline = cfg.data.train.dataset.pipeline
+        # set test_mode=False here in deep copied config
+        # which do not affect AP/AR calculation later
+        # refer to https://mmdetection3d.readthedocs.io/en/latest/tutorials/customize_runtime.html#customize-workflow  # noqa
+        val_dataset.test_mode = False
         datasets.append(build_dataset(val_dataset))
     if cfg.checkpoint_config is not None:
         # save mmdet version, config file content and class names in


### PR DESCRIPTION
Val in workflow is intended to show the losses on test set. This pr fixes a bug when adding val to workflow.

Still, val uses train-time data augmentations, which is not preferred. However, one can slightly modify the config files and train.py in order to use test-time data augmentations for val. Therefore we do not address the issue in this pr. Perhaps some refactors might be considered in the future regarding this issue (the test_mode meaning and pipeline overriding here are also a bit confusing)?