### PR TITLE
[Fix] Fix potential bug in ThreeNN

### DIFF
--- a/mmdet3d/ops/interpolate/three_nn.py
+++ b/mmdet3d/ops/interpolate/three_nn.py
@@ -32,6 +32,9 @@ class ThreeNN(Function):
         idx = torch.cuda.IntTensor(B, N, 3)
 
         interpolate_ext.three_nn_wrapper(B, N, m, target, source, dist2, idx)
+
+        ctx.mark_non_differentiable(idx)
+
         return torch.sqrt(dist2), idx
 
     @staticmethod


### PR DESCRIPTION
Currently this bug won't be triggered in the repo. However, when the indices calculated by ThreeNN participate in backwarding, there will be an error message: `RuntimeError: Expected isFloatingType(grads[i].scalar_type()) to be true, but got false.`

Please refer to https://github.com/facebookresearch/votenet/pull/72 and https://discuss.pytorch.org/t/custom-autograd-function-with-int-tensor-input/65907.