### PR TITLE
[Fix]: fix compilation error in pytorch 1.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        torch: [1.5.0+cu101, 1.6.0+cu101]
+        torch: [1.5.0+cu101, 1.6.0+cu101, 1.7.0+cu101]
         include:
           - torch: 1.5.0+cu101
             torchvision: 0.6.0+cu101
@@ -47,6 +47,10 @@ jobs:
           - torch: 1.6.0+cu101
             mmcv: 1.6.0+cu101
             torchvision: 0.7.0+cu101
+            cuda_arch: "7.0"
+          - torch: 1.7.0+cu101
+            mmcv: 1.7.0+cu101
+            torchvision: 0.8.0+cu101
             cuda_arch: "7.0"
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
             cuda_arch: "7.0"
           - torch: 1.7.0+cu101
             mmcv: 1.7.0+cu101
-            torchvision: 0.8.0+cu101
+            torchvision: 0.8.1+cu101
             cuda_arch: "7.0"
 
     steps:


### PR DESCRIPTION
In Pytorch 1.7, the cuda kernel of dynamic voxelization will cause compilation errors of `error: class "at::Tensor" has no member "max_values"` as mentioned in https://github.com/open-mmlab/mmdetection3d/issues/362. This PR changes to use tensor.max() to fix the error.

Resolves https://github.com/open-mmlab/mmdetection3d/issues/362