### PR TITLE
[Fix] Fix point type errors in docstring in pipeline functions

### DIFF
--- a/mmdet3d/datasets/pipelines/loading.py
+++ b/mmdet3d/datasets/pipelines/loading.py
@@ -154,7 +154,7 @@ class LoadPointsFromMultiSweeps(object):
         """Removes point too close within a certain radius from origin.
 
         Args:
-            points (np.ndarray): Sweep points.
+            points (np.ndarray | :obj:`BasePoints`): Sweep points.
             radius (float): Radius below which points are removed.
                 Defaults to 1.0.
 
@@ -183,7 +183,8 @@ class LoadPointsFromMultiSweeps(object):
             dict: The result dict containing the multi-sweep points data. \
                 Added key and value are described below.
 
-                - points (np.ndarray): Multi-sweep point cloud arrays.
+                - points (np.ndarray | :obj:`BasePoints`): Multi-sweep point \
+                    cloud arrays.
         """
         points = results['points']
         points.tensor[:, 4] = 0
@@ -295,7 +296,7 @@ class NormalizePointsColor(object):
             dict: The result dict containing the normalized points. \
                 Updated key and value are described below.
 
-                - points (np.ndarray): Points after color normalization.
+                - points (:obj:`BasePoints`): Points after color normalization.
         """
         points = results['points']
         assert points.attribute_dims is not None and \
@@ -393,7 +394,7 @@ class LoadPointsFromFile(object):
             dict: The result dict containing the point clouds data. \
                 Added key and value are described below.
 
-                - points (np.ndarray): Point clouds data.
+                - points (:obj:`BasePoints`): Point clouds data.
         """
         pts_filename = results['pts_filename']
         points = self._load_points(pts_filename)

--- a/mmdet3d/datasets/pipelines/transforms_3d.py
+++ b/mmdet3d/datasets/pipelines/transforms_3d.py
@@ -147,7 +147,7 @@ class ObjectSample(object):
         """Remove the points in the sampled bounding boxes.
 
         Args:
-            points (np.ndarray): Input point cloud array.
+            points (:obj:`BasePoints`): Input point cloud array.
             boxes (np.ndarray): Sampled ground truth boxes.
 
         Returns:
@@ -604,7 +604,7 @@ class IndoorPointSample(object):
         Sample points to a certain number.
 
         Args:
-            points (np.ndarray): 3D Points.
+            points (np.ndarray | :obj:`BasePoints`): 3D Points.
             num_samples (int): Number of samples to be sampled.
             replace (bool): Whether the sample is with or without replacement.
             Defaults to None.
@@ -613,7 +613,7 @@ class IndoorPointSample(object):
         Returns:
             tuple[np.ndarray] | np.ndarray:
 
-                - points (np.ndarray): 3D Points.
+                - points (np.ndarray | :obj:`BasePoints`): 3D Points.
                 - choices (np.ndarray, optional): The generated random samples.
         """
         if replace is None:
@@ -708,10 +708,10 @@ class IndoorPatchPointSample(object):
             attributes (np.ndarray): features of input points.
             attribute_dims (dict): Dictionary to indicate the meaning of extra
                 dimension.
-            point_type (type): class of input points.
+            point_type (type): class of input points inherited from BasePoints.
 
         Returns:
-            np.ndarray: The generated input data.
+            :obj:`BasePoints`: The generated input data.
         """
         # subtract patch center, the z dimension is not centered
         centered_coords = coords.copy()
@@ -742,15 +742,15 @@ class IndoorPatchPointSample(object):
         Then sample points within that patch to a certain number.
 
         Args:
-            points (BasePoints): 3D Points.
+            points (:obj:`BasePoints`): 3D Points.
             sem_mask (np.ndarray): semantic segmentation mask for input points.
             replace (bool): Whether the sample is with or without replacement.
                 Defaults to None.
 
         Returns:
-            tuple[np.ndarray] | np.ndarray:
+            tuple[:obj:`BasePoints`, np.ndarray] | :obj:`BasePoints`:
 
-                - points (BasePoints): 3D Points.
+                - points (:obj:`BasePoints`): 3D Points.
                 - choices (np.ndarray): The generated random samples.
         """
         coords = points.coord.numpy()


### PR DESCRIPTION
Fix [issue#411](https://github.com/open-mmlab/mmdetection3d/issues/411), so that developers will understand the points during loading pipeline are instances of BasePoints class. They need to take out the tensor/coord/attribute of points in case some operations are not supported by BasePoints class.