### PR TITLE
[Enhance] Add pipeline for data loading

### DIFF
--- a/configs/3dssd/3dssd_kitti-3d-car.py
+++ b/configs/3dssd/3dssd_kitti-3d-car.py
@@ -85,21 +85,6 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
-# construct a pipeline for data and gt loading in show function
-# please keep its loading function consistent with test_pipeline (e.g. client)
-eval_pipeline = [
-    dict(
-        type='LoadPointsFromFile',
-        coord_type='LIDAR',
-        load_dim=4,
-        use_dim=4,
-        file_client_args=file_client_args),
-    dict(
-        type='DefaultFormatBundle3D',
-        class_names=class_names,
-        with_label=False),
-    dict(type='Collect3D', keys=['points'])
-]
 
 data = dict(
     samples_per_gpu=4,
@@ -108,7 +93,7 @@ data = dict(
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))
 
-evaluation = dict(interval=2, pipeline=eval_pipeline)
+evaluation = dict(interval=2)
 
 # model settings
 model = dict(

--- a/configs/3dssd/3dssd_kitti-3d-car.py
+++ b/configs/3dssd/3dssd_kitti-3d-car.py
@@ -85,6 +85,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=4,
+        use_dim=4,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=4,
@@ -93,7 +108,7 @@ data = dict(
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))
 
-evaluation = dict(interval=2)
+evaluation = dict(interval=2, pipeline=eval_pipeline)
 
 # model settings
 model = dict(

--- a/configs/_base_/datasets/kitti-3d-3class.py
+++ b/configs/_base_/datasets/kitti-3d-3class.py
@@ -79,6 +79,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=4,
+        use_dim=4,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=6,
@@ -122,4 +137,4 @@ data = dict(
         test_mode=True,
         box_type_3d='LiDAR'))
 
-evaluation = dict(interval=1)
+evaluation = dict(interval=1, pipeline=eval_pipeline)

--- a/configs/_base_/datasets/kitti-3d-car.py
+++ b/configs/_base_/datasets/kitti-3d-car.py
@@ -77,6 +77,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=4,
+        use_dim=4,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=6,
@@ -120,4 +135,4 @@ data = dict(
         test_mode=True,
         box_type_3d='LiDAR'))
 
-evaluation = dict(interval=1)
+evaluation = dict(interval=1, pipeline=eval_pipeline)

--- a/configs/_base_/datasets/lyft-3d.py
+++ b/configs/_base_/datasets/lyft-3d.py
@@ -82,6 +82,25 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=10,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=2,
@@ -114,4 +133,4 @@ data = dict(
 # Since the models are trained by 24 epochs by default, we set evaluation
 # interval to be 24. Please change the interval accordingly if you do not
 # use a default schedule.
-evaluation = dict(interval=24)
+evaluation = dict(interval=24, pipeline=eval_pipeline)

--- a/configs/_base_/datasets/nus-3d.py
+++ b/configs/_base_/datasets/nus-3d.py
@@ -83,6 +83,25 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=10,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=4,
@@ -120,4 +139,4 @@ data = dict(
 # Since the models are trained by 24 epochs by default, we set evaluation
 # interval to be 24. Please change the interval accordingly if you do not
 # use a default schedule.
-evaluation = dict(interval=24)
+evaluation = dict(interval=24, pipeline=eval_pipeline)

--- a/configs/_base_/datasets/range100_lyft-3d.py
+++ b/configs/_base_/datasets/range100_lyft-3d.py
@@ -82,6 +82,25 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=10,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=2,
@@ -114,4 +133,4 @@ data = dict(
 # Since the models are trained by 24 epochs by default, we set evaluation
 # interval to be 24. Please change the interval accordingly if you do not
 # use a default schedule.
-evaluation = dict(interval=24)
+evaluation = dict(interval=24, pipeline=eval_pipeline)

--- a/configs/_base_/datasets/scannet-3d-18class.py
+++ b/configs/_base_/datasets/scannet-3d-18class.py
@@ -72,6 +72,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='DEPTH',
+        shift_height=False,
+        load_dim=6,
+        use_dim=[0, 1, 2]),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=8,
@@ -105,3 +120,5 @@ data = dict(
         classes=class_names,
         test_mode=True,
         box_type_3d='Depth'))
+
+evaluation = dict(pipeline=eval_pipeline)

--- a/configs/_base_/datasets/scannet_seg-3d-20class.py
+++ b/configs/_base_/datasets/scannet_seg-3d-20class.py
@@ -68,7 +68,10 @@ eval_pipeline = [
         type='PointSegClassMapping',
         valid_cat_ids=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 24, 28,
                        33, 34, 36, 39)),
-    dict(type='DefaultFormatBundle3D', class_names=class_names),
+    dict(
+        type='DefaultFormatBundle3D',
+        with_label=False,
+        class_names=class_names),
     dict(type='Collect3D', keys=['points', 'pts_semantic_mask'])
 ]
 

--- a/configs/_base_/datasets/scannet_seg-3d-20class.py
+++ b/configs/_base_/datasets/scannet_seg-3d-20class.py
@@ -47,6 +47,30 @@ test_pipeline = [
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points'])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+# we need to load gt seg_mask!
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='DEPTH',
+        shift_height=False,
+        use_color=True,
+        load_dim=6,
+        use_dim=[0, 1, 2, 3, 4, 5]),
+    dict(
+        type='LoadAnnotations3D',
+        with_bbox_3d=False,
+        with_label_3d=False,
+        with_mask_3d=False,
+        with_seg_3d=True),
+    dict(
+        type='PointSegClassMapping',
+        valid_cat_ids=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 24, 28,
+                       33, 34, 36, 39)),
+    dict(type='DefaultFormatBundle3D', class_names=class_names),
+    dict(type='Collect3D', keys=['points', 'pts_semantic_mask'])
+]
 
 data = dict(
     samples_per_gpu=8,
@@ -77,3 +101,5 @@ data = dict(
         classes=class_names,
         test_mode=True,
         ignore_index=len(class_names)))
+
+evaluation = dict(pipeline=eval_pipeline)

--- a/configs/_base_/datasets/sunrgbd-3d-10class.py
+++ b/configs/_base_/datasets/sunrgbd-3d-10class.py
@@ -55,6 +55,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='DEPTH',
+        shift_height=False,
+        load_dim=6,
+        use_dim=[0, 1, 2]),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=16,
@@ -88,3 +103,5 @@ data = dict(
         classes=class_names,
         test_mode=True,
         box_type_3d='Depth'))
+
+evaluation = dict(pipeline=eval_pipeline)

--- a/configs/_base_/datasets/waymoD5-3d-3class.py
+++ b/configs/_base_/datasets/waymoD5-3d-3class.py
@@ -84,6 +84,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=6,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=2,
@@ -126,4 +141,4 @@ data = dict(
         test_mode=True,
         box_type_3d='LiDAR'))
 
-evaluation = dict(interval=24)
+evaluation = dict(interval=24, pipeline=eval_pipeline)

--- a/configs/_base_/datasets/waymoD5-3d-car.py
+++ b/configs/_base_/datasets/waymoD5-3d-car.py
@@ -83,6 +83,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=6,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=2,
@@ -125,4 +140,4 @@ data = dict(
         test_mode=True,
         box_type_3d='LiDAR'))
 
-evaluation = dict(interval=24)
+evaluation = dict(interval=24, pipeline=eval_pipeline)

--- a/configs/benchmark/hv_PartA2_secfpn_4x8_cyclic_80e_pcdet_kitti-3d-3class.py
+++ b/configs/benchmark/hv_PartA2_secfpn_4x8_cyclic_80e_pcdet_kitti-3d-3class.py
@@ -253,6 +253,16 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=4,
@@ -302,7 +312,7 @@ momentum_config = dict(
     cyclic_times=1,
     step_ratio_up=0.4)
 checkpoint_config = dict(interval=1)
-evaluation = dict(interval=1)
+evaluation = dict(interval=1, pipeline=eval_pipeline)
 # yapf:disable
 log_config = dict(
     interval=50,

--- a/configs/benchmark/hv_pointpillars_secfpn_3x8_100e_det3d_kitti-3d-car.py
+++ b/configs/benchmark/hv_pointpillars_secfpn_3x8_100e_det3d_kitti-3d-car.py
@@ -115,6 +115,16 @@ test_pipeline = [
         with_label=False),
     dict(type='Collect3D', keys=['points'])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=3,
@@ -172,7 +182,7 @@ momentum_config = dict(
     cyclic_times=1,
     step_ratio_up=0.4)
 checkpoint_config = dict(interval=1)
-evaluation = dict(interval=1)
+evaluation = dict(interval=1, pipeline=eval_pipeline)
 # yapf:disable
 log_config = dict(
     interval=50,

--- a/configs/benchmark/hv_pointpillars_secfpn_4x8_80e_pcdet_kitti-3d-3class.py
+++ b/configs/benchmark/hv_pointpillars_secfpn_4x8_80e_pcdet_kitti-3d-3class.py
@@ -161,6 +161,16 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=4,
@@ -215,7 +225,7 @@ momentum_config = dict(
     cyclic_times=1,
     step_ratio_up=0.4)
 checkpoint_config = dict(interval=1)
-evaluation = dict(interval=2)
+evaluation = dict(interval=2, pipeline=eval_pipeline)
 # yapf:disable
 log_config = dict(
     interval=50,

--- a/configs/benchmark/hv_second_secfpn_4x8_80e_pcdet_kitti-3d-3class.py
+++ b/configs/benchmark/hv_second_secfpn_4x8_80e_pcdet_kitti-3d-3class.py
@@ -168,6 +168,21 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=4,
+        use_dim=4,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=4,
@@ -217,7 +232,7 @@ momentum_config = dict(
     cyclic_times=1,
     step_ratio_up=0.4)
 checkpoint_config = dict(interval=1)
-evaluation = dict(interval=2)
+evaluation = dict(interval=2, pipeline=eval_pipeline)
 # yapf:disable
 log_config = dict(
     interval=50,

--- a/configs/centerpoint/centerpoint_0075voxel_second_secfpn_4x8_cyclic_20e_nus.py
+++ b/configs/centerpoint/centerpoint_0075voxel_second_secfpn_4x8_cyclic_20e_nus.py
@@ -133,32 +133,8 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
-# construct a pipeline for data and gt loading in show function
-# please keep its loading function consistent with test_pipeline (e.g. client)
-eval_pipeline = [
-    dict(
-        type='LoadPointsFromFile',
-        coord_type='LIDAR',
-        load_dim=5,
-        use_dim=5,
-        file_client_args=file_client_args),
-    dict(
-        type='LoadPointsFromMultiSweeps',
-        sweeps_num=9,
-        use_dim=[0, 1, 2, 3, 4],
-        file_client_args=file_client_args,
-        pad_empty_sweeps=True,
-        remove_close=True),
-    dict(
-        type='DefaultFormatBundle3D',
-        class_names=class_names,
-        with_label=False),
-    dict(type='Collect3D', keys=['points'])
-]
 
 data = dict(
     train=dict(dataset=dict(pipeline=train_pipeline)),
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))
-
-evaluation = dict(interval=20, pipeline=eval_pipeline)

--- a/configs/centerpoint/centerpoint_0075voxel_second_secfpn_4x8_cyclic_20e_nus.py
+++ b/configs/centerpoint/centerpoint_0075voxel_second_secfpn_4x8_cyclic_20e_nus.py
@@ -133,8 +133,32 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=9,
+        use_dim=[0, 1, 2, 3, 4],
+        file_client_args=file_client_args,
+        pad_empty_sweeps=True,
+        remove_close=True),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     train=dict(dataset=dict(pipeline=train_pipeline)),
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))
+
+evaluation = dict(interval=20, pipeline=eval_pipeline)

--- a/configs/centerpoint/centerpoint_01voxel_second_secfpn_4x8_cyclic_20e_nus.py
+++ b/configs/centerpoint/centerpoint_01voxel_second_secfpn_4x8_cyclic_20e_nus.py
@@ -128,6 +128,28 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=9,
+        use_dim=[0, 1, 2, 3, 4],
+        file_client_args=file_client_args,
+        pad_empty_sweeps=True,
+        remove_close=True),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     train=dict(
@@ -146,4 +168,4 @@ data = dict(
     val=dict(pipeline=test_pipeline, classes=class_names),
     test=dict(pipeline=test_pipeline, classes=class_names))
 
-evaluation = dict(interval=20)
+evaluation = dict(interval=20, pipeline=eval_pipeline)

--- a/configs/centerpoint/centerpoint_02pillar_second_secfpn_4x8_cyclic_20e_nus.py
+++ b/configs/centerpoint/centerpoint_02pillar_second_secfpn_4x8_cyclic_20e_nus.py
@@ -127,6 +127,28 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=9,
+        use_dim=[0, 1, 2, 3, 4],
+        file_client_args=file_client_args,
+        pad_empty_sweeps=True,
+        remove_close=True),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     train=dict(
@@ -145,4 +167,4 @@ data = dict(
     val=dict(pipeline=test_pipeline, classes=class_names),
     test=dict(pipeline=test_pipeline, classes=class_names))
 
-evaluation = dict(interval=20)
+evaluation = dict(interval=20, pipeline=eval_pipeline)

--- a/configs/free_anchor/hv_pointpillars_regnet-1.6gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
+++ b/configs/free_anchor/hv_pointpillars_regnet-1.6gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
@@ -62,8 +62,27 @@ train_pipeline = [
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points', 'gt_bboxes_3d', 'gt_labels_3d'])
 ]
-data = dict(train=dict(pipeline=train_pipeline))
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=10,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
+data = dict(train=dict(pipeline=train_pipeline))
 lr_config = dict(step=[28, 34])
-evaluation = dict(interval=36)
 runner = dict(max_epochs=36)
+evaluation = dict(interval=36, pipeline=eval_pipeline)

--- a/configs/free_anchor/hv_pointpillars_regnet-1.6gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
+++ b/configs/free_anchor/hv_pointpillars_regnet-1.6gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
@@ -62,8 +62,8 @@ train_pipeline = [
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points', 'gt_bboxes_3d', 'gt_labels_3d'])
 ]
-
 data = dict(train=dict(pipeline=train_pipeline))
+
 lr_config = dict(step=[28, 34])
 runner = dict(max_epochs=36)
 evaluation = dict(interval=36)

--- a/configs/free_anchor/hv_pointpillars_regnet-1.6gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
+++ b/configs/free_anchor/hv_pointpillars_regnet-1.6gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
@@ -62,27 +62,8 @@ train_pipeline = [
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points', 'gt_bboxes_3d', 'gt_labels_3d'])
 ]
-# construct a pipeline for data and gt loading in show function
-# please keep its loading function consistent with test_pipeline (e.g. client)
-eval_pipeline = [
-    dict(
-        type='LoadPointsFromFile',
-        coord_type='LIDAR',
-        load_dim=5,
-        use_dim=5,
-        file_client_args=file_client_args),
-    dict(
-        type='LoadPointsFromMultiSweeps',
-        sweeps_num=10,
-        file_client_args=file_client_args),
-    dict(
-        type='DefaultFormatBundle3D',
-        class_names=class_names,
-        with_label=False),
-    dict(type='Collect3D', keys=['points'])
-]
 
 data = dict(train=dict(pipeline=train_pipeline))
 lr_config = dict(step=[28, 34])
 runner = dict(max_epochs=36)
-evaluation = dict(interval=36, pipeline=eval_pipeline)
+evaluation = dict(interval=36)

--- a/configs/free_anchor/hv_pointpillars_regnet-3.2gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
+++ b/configs/free_anchor/hv_pointpillars_regnet-3.2gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
@@ -62,8 +62,27 @@ train_pipeline = [
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points', 'gt_bboxes_3d', 'gt_labels_3d'])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(
+        type='LoadPointsFromMultiSweeps',
+        sweeps_num=10,
+        file_client_args=file_client_args),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(train=dict(pipeline=train_pipeline))
 lr_config = dict(step=[28, 34])
-evaluation = dict(interval=36)
 runner = dict(max_epochs=36)
+evaluation = dict(interval=36, pipeline=eval_pipeline)

--- a/configs/free_anchor/hv_pointpillars_regnet-3.2gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
+++ b/configs/free_anchor/hv_pointpillars_regnet-3.2gf_fpn_sbn-all_free-anchor_strong-aug_4x8_3x_nus-3d.py
@@ -62,27 +62,8 @@ train_pipeline = [
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points', 'gt_bboxes_3d', 'gt_labels_3d'])
 ]
-# construct a pipeline for data and gt loading in show function
-# please keep its loading function consistent with test_pipeline (e.g. client)
-eval_pipeline = [
-    dict(
-        type='LoadPointsFromFile',
-        coord_type='LIDAR',
-        load_dim=5,
-        use_dim=5,
-        file_client_args=file_client_args),
-    dict(
-        type='LoadPointsFromMultiSweeps',
-        sweeps_num=10,
-        file_client_args=file_client_args),
-    dict(
-        type='DefaultFormatBundle3D',
-        class_names=class_names,
-        with_label=False),
-    dict(type='Collect3D', keys=['points'])
-]
 
 data = dict(train=dict(pipeline=train_pipeline))
 lr_config = dict(step=[28, 34])
 runner = dict(max_epochs=36)
-evaluation = dict(interval=36, pipeline=eval_pipeline)
+evaluation = dict(interval=36)

--- a/configs/imvotenet/imvotenet_stage2_16x8_sunrgbd-3d-10class.py
+++ b/configs/imvotenet/imvotenet_stage2_16x8_sunrgbd-3d-10class.py
@@ -233,11 +233,28 @@ test_pipeline = [
             dict(type='Collect3D', keys=['img', 'points', 'calib'])
         ]),
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='DEPTH',
+        shift_height=False,
+        load_dim=6,
+        use_dim=[0, 1, 2]),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['img', 'points', 'calib'])
+]
 
 data = dict(
     train=dict(dataset=dict(pipeline=train_pipeline)),
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))
+evaluation = dict(pipeline=eval_pipeline)
 
 # may also use your own pre-trained image branch
 load_from = 'https://download.openmmlab.com/mmdetection3d/v0.1.0_models/imvotenet/imvotenet_faster_rcnn_r50_fpn_2x4_sunrgbd-3d-10class/imvotenet_faster_rcnn_r50_fpn_2x4_sunrgbd-3d-10class_20210323_173222-cad62aeb.pth'  # noqa

--- a/configs/mvxnet/dv_mvx-fpn_second_secfpn_adamw_2x8_80e_kitti-3d-3class.py
+++ b/configs/mvxnet/dv_mvx-fpn_second_secfpn_adamw_2x8_80e_kitti-3d-3class.py
@@ -186,6 +186,17 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points', 'img'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points', 'img'])
+]
 
 data = dict(
     samples_per_gpu=2,
@@ -246,7 +257,7 @@ log_config = dict(
         dict(type='TensorboardLoggerHook')
     ])
 # yapf:enable
-evaluation = dict(interval=1)
+evaluation = dict(interval=1, pipeline=eval_pipeline)
 # runtime settings
 runner = dict(max_epochs=40)
 dist_params = dict(backend='nccl')

--- a/configs/parta2/hv_PartA2_secfpn_2x8_cyclic_80e_kitti-3d-3class.py
+++ b/configs/parta2/hv_PartA2_secfpn_2x8_cyclic_80e_kitti-3d-3class.py
@@ -260,6 +260,16 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     samples_per_gpu=2,
@@ -301,4 +311,5 @@ data = dict(
 # Part-A2 uses a different learning rate from what SECOND uses.
 lr = 0.001
 optimizer = dict(lr=lr)
+evaluation = dict(pipeline=eval_pipeline)
 find_unused_parameters = True

--- a/configs/pointpillars/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class.py
+++ b/configs/pointpillars/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class.py
@@ -64,6 +64,16 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
+# construct a pipeline for data and gt loading in show function
+# please keep its loading function consistent with test_pipeline (e.g. client)
+eval_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=class_names,
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+]
 
 data = dict(
     train=dict(dataset=dict(pipeline=train_pipeline, classes=class_names)),
@@ -79,7 +89,7 @@ optimizer = dict(lr=lr)
 # specifically tune this parameter.
 optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
 # Use evaluation interval=2 reduce the number of evaluation timese
-evaluation = dict(interval=2)
+evaluation = dict(interval=2, pipeline=eval_pipeline)
 # PointPillars usually need longer schedule than second, we simply double
 # the training schedule. Do remind that since we use RepeatDataset and
 # repeat factor is 2, so we actually train 160 epochs.

--- a/configs/pointpillars/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class.py
+++ b/configs/pointpillars/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class.py
@@ -64,16 +64,6 @@ test_pipeline = [
             dict(type='Collect3D', keys=['points'])
         ])
 ]
-# construct a pipeline for data and gt loading in show function
-# please keep its loading function consistent with test_pipeline (e.g. client)
-eval_pipeline = [
-    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
-    dict(
-        type='DefaultFormatBundle3D',
-        class_names=class_names,
-        with_label=False),
-    dict(type='Collect3D', keys=['points'])
-]
 
 data = dict(
     train=dict(dataset=dict(pipeline=train_pipeline, classes=class_names)),
@@ -89,7 +79,7 @@ optimizer = dict(lr=lr)
 # specifically tune this parameter.
 optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
 # Use evaluation interval=2 reduce the number of evaluation timese
-evaluation = dict(interval=2, pipeline=eval_pipeline)
+evaluation = dict(interval=2)
 # PointPillars usually need longer schedule than second, we simply double
 # the training schedule. Do remind that since we use RepeatDataset and
 # repeat factor is 2, so we actually train 160 epochs.

--- a/docs/tutorials/config.md
+++ b/docs/tutorials/config.md
@@ -242,6 +242,22 @@ test_pipeline = [  # Testing pipeline, refer to mmdet3d.datasets.pipelines for m
     dict(type='Collect3D',  # Pipeline that decides which keys in the data should be passed to the detector, refer to mmdet3d.datasets.pipelines.formating for more details
         keys=['points'])
 ]
+eval_pipeline = [  # Pipeline used for evaluation or visualization, refer to mmdet3d.datasets.pipelines for more details
+    dict(
+        type='LoadPointsFromFile',  # First pipeline to load points, refer to mmdet3d.datasets.pipelines.indoor_loading for more details
+        shift_height=True,  # Whether to use shifted height
+        load_dim=6,  # The dimension of the loaded points
+        use_dim=[0, 1, 2]),  # Which dimensions of the points to be used
+    dict(
+        type='DefaultFormatBundle3D',  # Default format bundle to gather data in the pipeline, refer to mmdet3d.datasets.pipelines.formating for more details
+        class_names=('cabinet', 'bed', 'chair', 'sofa', 'table', 'door',
+                     'window', 'bookshelf', 'picture', 'counter', 'desk',
+                     'curtain', 'refrigerator', 'showercurtrain', 'toilet',
+                     'sink', 'bathtub', 'garbagebin')),
+        with_label=False),
+    dict(type='Collect3D',  # Pipeline that decides which keys in the data should be passed to the detector, refer to mmdet3d.datasets.pipelines.formating for more details
+        keys=['points'])
+]
 data = dict(
     samples_per_gpu=8,  # Batch size of a single GPU
     workers_per_gpu=4,  # Worker to pre-fetch data for each single GPU
@@ -347,6 +363,22 @@ data = dict(
                  'refrigerator', 'showercurtrain', 'toilet', 'sink', 'bathtub',
                  'garbagebin'),  # Names of classes
         test_mode=True))  # Whether to use test mode
+evaluation = dict(pipeline=[  # Pipeline is passed by eval_pipeline created before
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='DEPTH',
+        shift_height=False,
+        load_dim=6,
+        use_dim=[0, 1, 2]),
+    dict(
+        type='DefaultFormatBundle3D',
+        class_names=('cabinet', 'bed', 'chair', 'sofa', 'table', 'door',
+                     'window', 'bookshelf', 'picture', 'counter', 'desk',
+                     'curtain', 'refrigerator', 'showercurtrain', 'toilet',
+                     'sink', 'bathtub', 'garbagebin'),
+        with_label=False),
+    dict(type='Collect3D', keys=['points'])
+])
 lr = 0.008  # Learning rate of optimizers
 optimizer = dict(  # Config used to build optimizer, support all the optimizers in PyTorch whose arguments are also the same as those in PyTorch
     type='Adam',  # Type of optimizers,   # Type of optimizers, refer to https://github.com/open-mmlab/mmdetection/blob/master/mmdet/core/optimizer/default_constructor.py#L13 for more details

--- a/mmdet3d/datasets/custom_3d.py
+++ b/mmdet3d/datasets/custom_3d.py
@@ -226,7 +226,8 @@ class Custom3DDataset(Dataset):
                  iou_thr=(0.25, 0.5),
                  logger=None,
                  show=False,
-                 out_dir=None):
+                 out_dir=None,
+                 pipeline=None):
         """Evaluate.
 
         Evaluation in indoor protocol.
@@ -238,6 +239,8 @@ class Custom3DDataset(Dataset):
             show (bool): Whether to visualize.
                 Default: False.
             out_dir (str): Path to save the visualization results.
+                Default: None.
+            pipeline (list[dict], optional): raw data loading for showing.
                 Default: None.
 
         Returns:
@@ -262,9 +265,28 @@ class Custom3DDataset(Dataset):
             box_type_3d=self.box_type_3d,
             box_mode_3d=self.box_mode_3d)
         if show:
-            self.show(results, out_dir)
+            self.show(results, out_dir, pipeline=pipeline)
 
         return ret_dict
+
+    @staticmethod
+    def _extract_data(results, key):
+        """Extract and return the data corresponding to key in results dict.
+
+        Args:
+            results (dict): Result dict containing point clouds data.
+            key (str): Key of the desired data.
+
+        Returns:
+            np.ndarray | torch.Tensor: Data term.
+        """
+        # results[key] may be DataContainer or list[DataContainer]
+        if isinstance(results[key], mmcv.parallel.DataContainer):
+            data = results[key]._data
+        else:  # list output of MultiScaleFlipAug3D
+            data = results[key][0]._data
+
+        return data
 
     def __len__(self):
         """Return the length of data infos.

--- a/mmdet3d/datasets/custom_3d.py
+++ b/mmdet3d/datasets/custom_3d.py
@@ -280,11 +280,13 @@ class Custom3DDataset(Dataset):
         Returns:
             np.ndarray | torch.Tensor: Data term.
         """
-        # results[key] may be DataContainer or list[DataContainer]
-        if isinstance(results[key], mmcv.parallel.DataContainer):
-            data = results[key]._data
-        else:  # list output of MultiScaleFlipAug3D
-            data = results[key][0]._data
+        # results[key] may be data or list[data]
+        # data may be wrapped inside DataContainer
+        data = results[key]
+        if isinstance(data, list) or isinstance(data, tuple):
+            data = data[0]
+        if isinstance(data, mmcv.parallel.DataContainer):
+            data = data._data
 
         return data
 

--- a/mmdet3d/datasets/custom_3d.py
+++ b/mmdet3d/datasets/custom_3d.py
@@ -273,7 +273,8 @@ class Custom3DDataset(Dataset):
 
     def _build_default_pipeline(self):
         """Build the default pipeline for this dataset."""
-        pass
+        raise NotImplementedError('_build_default_pipeline is not implemented '
+                                  f'for dataset {self.__class__.__name__}')
 
     def _get_pipeline(self, pipeline):
         """Get data loading pipeline in self.show/evaluate function.

--- a/mmdet3d/datasets/custom_3d.py
+++ b/mmdet3d/datasets/custom_3d.py
@@ -330,6 +330,8 @@ class Custom3DDataset(Dataset):
                 A single or a list of loaded data.
         """
         assert pipeline is not None, 'data loading pipeline is not provided'
+        # when we want to load ground-truth via pipeline (e.g. bbox, seg mask)
+        # we need to set self.test_mode as False so that we have 'annos'
         if load_annos:
             original_test_mode = self.test_mode
             self.test_mode = False

--- a/mmdet3d/datasets/custom_3d_seg.py
+++ b/mmdet3d/datasets/custom_3d_seg.py
@@ -431,6 +431,8 @@ class Custom3DSegDataset(Dataset):
                 A single or a list of loaded data.
         """
         assert pipeline is not None, 'data loading pipeline is not provided'
+        # when we want to load ground-truth via pipeline (e.g. bbox, seg mask)
+        # we need to set self.test_mode as False so that we have 'annos'
         if load_annos:
             original_test_mode = self.test_mode
             self.test_mode = False

--- a/mmdet3d/datasets/custom_3d_seg.py
+++ b/mmdet3d/datasets/custom_3d_seg.py
@@ -374,7 +374,8 @@ class Custom3DSegDataset(Dataset):
 
     def _build_default_pipeline(self):
         """Build the default pipeline for this dataset."""
-        pass
+        raise NotImplementedError('_build_default_pipeline is not implemented '
+                                  f'for dataset {self.__class__.__name__}')
 
     def _get_pipeline(self, pipeline):
         """Get data loading pipeline in self.show/evaluate function.

--- a/mmdet3d/datasets/custom_3d_seg.py
+++ b/mmdet3d/datasets/custom_3d_seg.py
@@ -394,6 +394,28 @@ class Custom3DSegDataset(Dataset):
             return Compose(loading_pipeline)
         return Compose(pipeline)
 
+    @staticmethod
+    def _get_data(results, key):
+        """Extract and return the data corresponding to key in result dict.
+
+        Args:
+            results (dict): Data loaded using pipeline.
+            key (str): Key of the desired data.
+
+        Returns:
+            np.ndarray | torch.Tensor | None: Data term.
+        """
+        if key not in results.keys():
+            return None
+        # results[key] may be data or list[data]
+        # data may be wrapped inside DataContainer
+        data = results[key]
+        if isinstance(data, list) or isinstance(data, tuple):
+            data = data[0]
+        if isinstance(data, mmcv.parallel.DataContainer):
+            data = data._data
+        return data
+
     def _extract_data(self, index, pipeline, key, load_annos=False):
         """Load data using input pipeline and extract data according to key.
 
@@ -416,30 +438,11 @@ class Custom3DSegDataset(Dataset):
         self.pre_pipeline(input_dict)
         example = pipeline(input_dict)
 
-        def get_data(key):
-            """Extract and return the data corresponding to key in result dict.
-
-            Args:
-                key (str): Key of the desired data.
-
-            Returns:
-                np.ndarray | torch.Tensor | None: Data term.
-            """
-            if key not in example.keys():
-                return None
-            # example[key] may be data or list[data]
-            # data may be wrapped inside DataContainer
-            data = example[key]
-            if isinstance(data, list) or isinstance(data, tuple):
-                data = data[0]
-            if isinstance(data, mmcv.parallel.DataContainer):
-                data = data._data
-            return data
-
+        # extract data items according to keys
         if isinstance(key, str):
-            data = get_data(key)
+            data = self._get_data(example, key)
         else:
-            data = [get_data(k) for k in key]
+            data = [self._get_data(example, k) for k in key]
         if load_annos:
             self.test_mode = original_test_mode
 

--- a/mmdet3d/datasets/kitti_dataset.py
+++ b/mmdet3d/datasets/kitti_dataset.py
@@ -689,6 +689,8 @@ class KittiDataset(Custom3DDataset):
                 hasattr(self, 'pipeline') else None  # save the original one
             self.pipeline = pipeline  # set new pipeline for data loading
         for i, result in enumerate(results):
+            if 'pts_bbox' in result.keys():
+                result = result['pts_bbox']
             example = self.prepare_test_data(i)
             data_info = self.data_infos[i]
             pts_path = data_info['point_cloud']['velodyne_path']

--- a/mmdet3d/datasets/kitti_dataset.py
+++ b/mmdet3d/datasets/kitti_dataset.py
@@ -12,6 +12,7 @@ from ..core import show_multi_modality_result, show_result
 from ..core.bbox import (Box3DMode, CameraInstance3DBoxes, Coord3DMode,
                          LiDARInstance3DBoxes, points_cam2img)
 from .custom_3d import Custom3DDataset
+from .pipelines import Compose
 
 
 @DATASETS.register_module()
@@ -300,7 +301,8 @@ class KittiDataset(Custom3DDataset):
                  pklfile_prefix=None,
                  submission_prefix=None,
                  show=False,
-                 out_dir=None):
+                 out_dir=None,
+                 pipeline=None):
         """Evaluation in KITTI protocol.
 
         Args:
@@ -316,6 +318,8 @@ class KittiDataset(Custom3DDataset):
             show (bool): Whether to visualize.
                 Default: False.
             out_dir (str): Path to save the visualization results.
+                Default: None.
+            pipeline (list[dict], optional): raw data loading for showing.
                 Default: None.
 
         Returns:
@@ -354,7 +358,7 @@ class KittiDataset(Custom3DDataset):
         if tmp_dir is not None:
             tmp_dir.cleanup()
         if show:
-            self.show(results, out_dir)
+            self.show(results, out_dir, pipeline=pipeline)
         return ap_dict
 
     def bbox2result_kitti(self,
@@ -668,22 +672,29 @@ class KittiDataset(Custom3DDataset):
                 label_preds=np.zeros([0, 4]),
                 sample_idx=sample_idx)
 
-    def show(self, results, out_dir, show=True):
+    def show(self, results, out_dir, show=True, pipeline=None):
         """Results visualization.
 
         Args:
             results (list[dict]): List of bounding boxes results.
             out_dir (str): Output directory of visualization result.
             show (bool): Visualize the results online.
+            pipeline (list[dict], optional): raw data loading for showing.
+                Default: None.
         """
         assert out_dir is not None, 'Expect out_dir, got none.'
+        if pipeline is not None:
+            pipeline = Compose(pipeline)
+            original_pipeline = self.pipeline if \
+                hasattr(self, 'pipeline') else None  # save the original one
+            self.pipeline = pipeline  # set new pipeline for data loading
         for i, result in enumerate(results):
             example = self.prepare_test_data(i)
             data_info = self.data_infos[i]
             pts_path = data_info['point_cloud']['velodyne_path']
             file_name = osp.split(pts_path)[-1].split('.')[0]
             # for now we convert points into depth mode
-            points = example['points'][0]._data.numpy()
+            points = self._extract_data(example, 'points').numpy()
             points = Coord3DMode.convert_point(points, Coord3DMode.LIDAR,
                                                Coord3DMode.DEPTH)
             gt_bboxes = self.get_ann_info(i)['gt_bboxes_3d'].tensor.numpy()
@@ -696,9 +707,11 @@ class KittiDataset(Custom3DDataset):
                         file_name, show)
 
             # multi-modality visualization
-            if self.modality['use_camera'] and \
-                    'lidar2img' in example['img_metas'][0]._data.keys():
-                img = mmcv.imread(example['img_metas'][0]._data['filename'])
+            img_metas = self._extract_data(example, 'img_metas')
+            if self.modality['use_camera'] and 'lidar2img' in img_metas.keys():
+                img = self._extract_data(example, 'img').numpy()
+                # need to transpose channel to first dim
+                img = img.transpose(1, 2, 0)
                 show_pred_bboxes = LiDARInstance3DBoxes(
                     pred_bboxes, origin=(0.5, 0.5, 0))
                 show_gt_bboxes = LiDARInstance3DBoxes(
@@ -707,7 +720,12 @@ class KittiDataset(Custom3DDataset):
                     img,
                     show_gt_bboxes,
                     show_pred_bboxes,
-                    example['img_metas'][0]._data['lidar2img'],
+                    img_metas['lidar2img'],
                     out_dir,
                     file_name,
                     show=False)
+        if pipeline is not None:  # switch back to original pipeline
+            if original_pipeline is not None:
+                self.pipeline = original_pipeline
+            else:
+                delattr(self, 'pipeline')

--- a/mmdet3d/datasets/kitti_dataset.py
+++ b/mmdet3d/datasets/kitti_dataset.py
@@ -674,35 +674,21 @@ class KittiDataset(Custom3DDataset):
 
     def _build_default_pipeline(self):
         """Build the default pipeline for this dataset."""
+        pipeline = [
+            dict(
+                type='LoadPointsFromFile',
+                coord_type='LIDAR',
+                load_dim=4,
+                use_dim=4,
+                file_client_args=dict(backend='disk')),
+            dict(
+                type='DefaultFormatBundle3D',
+                class_names=self.CLASSES,
+                with_label=False),
+            dict(type='Collect3D', keys=['points'])
+        ]
         if self.modality['use_camera']:
-            pipeline = [
-                dict(
-                    type='LoadPointsFromFile',
-                    coord_type='LIDAR',
-                    load_dim=4,
-                    use_dim=4,
-                    file_client_args=dict(backend='disk')),
-                dict(type='LoadImageFromFile'),
-                dict(
-                    type='DefaultFormatBundle3D',
-                    class_names=self.CLASSES,
-                    with_label=False),
-                dict(type='Collect3D', keys=['points', 'img'])
-            ]
-        else:
-            pipeline = [
-                dict(
-                    type='LoadPointsFromFile',
-                    coord_type='LIDAR',
-                    load_dim=4,
-                    use_dim=4,
-                    file_client_args=dict(backend='disk')),
-                dict(
-                    type='DefaultFormatBundle3D',
-                    class_names=self.CLASSES,
-                    with_label=False),
-                dict(type='Collect3D', keys=['points'])
-            ]
+            pipeline.insert(0, dict(type='LoadImageFromFile'))
         return Compose(pipeline)
 
     def show(self, results, out_dir, show=True, pipeline=None):

--- a/mmdet3d/datasets/lyft_dataset.py
+++ b/mmdet3d/datasets/lyft_dataset.py
@@ -12,6 +12,7 @@ from mmdet.datasets import DATASETS
 from ..core import show_result
 from ..core.bbox import Box3DMode, Coord3DMode, LiDARInstance3DBoxes
 from .custom_3d import Custom3DDataset
+from .pipelines import Compose
 
 
 @DATASETS.register_module()
@@ -356,7 +357,8 @@ class LyftDataset(Custom3DDataset):
                  csv_savepath=None,
                  result_names=['pts_bbox'],
                  show=False,
-                 out_dir=None):
+                 out_dir=None,
+                 pipeline=None):
         """Evaluation in Lyft protocol.
 
         Args:
@@ -374,6 +376,8 @@ class LyftDataset(Custom3DDataset):
             show (bool): Whether to visualize.
                 Default: False.
             out_dir (str): Path to save the visualization results.
+                Default: None.
+            pipeline (list[dict], optional): raw data loading for showing.
                 Default: None.
 
         Returns:
@@ -395,33 +399,46 @@ class LyftDataset(Custom3DDataset):
             tmp_dir.cleanup()
 
         if show:
-            self.show(results, out_dir)
+            self.show(results, out_dir, pipeline=pipeline)
         return results_dict
 
-    def show(self, results, out_dir):
+    def show(self, results, out_dir, show=True, pipeline=None):
         """Results visualization.
 
         Args:
             results (list[dict]): List of bounding boxes results.
             out_dir (str): Output directory of visualization result.
+            pipeline (list[dict], optional): raw data loading for showing.
+                Default: None.
         """
+        assert out_dir is not None, 'Expect out_dir, got none.'
+        if pipeline is not None:
+            pipeline = Compose(pipeline)
+            original_pipeline = self.pipeline if \
+                hasattr(self, 'pipeline') else None  # save the original one
+            self.pipeline = pipeline  # set new pipeline for data loading
         for i, result in enumerate(results):
             example = self.prepare_test_data(i)
-            points = example['points'][0]._data.numpy()
             data_info = self.data_infos[i]
             pts_path = data_info['lidar_path']
             file_name = osp.split(pts_path)[-1].split('.')[0]
             # for now we convert points into depth mode
+            points = self._extract_data(example, 'points').numpy()
             points = Coord3DMode.convert_point(points, Coord3DMode.LIDAR,
                                                Coord3DMode.DEPTH)
-            inds = result['pts_bbox']['scores_3d'] > 0.1
             gt_bboxes = self.get_ann_info(i)['gt_bboxes_3d'].tensor.numpy()
-            gt_bboxes = Box3DMode.convert(gt_bboxes, Box3DMode.LIDAR,
-                                          Box3DMode.DEPTH)
-            pred_bboxes = result['pts_bbox']['boxes_3d'][inds].tensor.numpy()
-            pred_bboxes = Box3DMode.convert(pred_bboxes, Box3DMode.LIDAR,
-                                            Box3DMode.DEPTH)
-            show_result(points, gt_bboxes, pred_bboxes, out_dir, file_name)
+            show_gt_bboxes = Box3DMode.convert(gt_bboxes, Box3DMode.LIDAR,
+                                               Box3DMode.DEPTH)
+            pred_bboxes = result['boxes_3d'].tensor.numpy()
+            show_pred_bboxes = Box3DMode.convert(pred_bboxes, Box3DMode.LIDAR,
+                                                 Box3DMode.DEPTH)
+            show_result(points, show_gt_bboxes, show_pred_bboxes, out_dir,
+                        file_name, show)
+        if pipeline is not None:  # switch back to original pipeline
+            if original_pipeline is not None:
+                self.pipeline = original_pipeline
+            else:
+                delattr(self, 'pipeline')
 
     def json2csv(self, json_path, csv_savepath):
         """Convert the json file to csv format for submission.

--- a/mmdet3d/datasets/nuscenes_dataset.py
+++ b/mmdet3d/datasets/nuscenes_dataset.py
@@ -455,7 +455,23 @@ class NuScenesDataset(Custom3DDataset):
                  result_names=['pts_bbox'],
                  show=False,
                  out_dir=None,
-                 pipeline=None):
+                 pipeline=[
+                     dict(
+                         type='LoadPointsFromFile',
+                         coord_type='LIDAR',
+                         load_dim=5,
+                         use_dim=5,
+                         file_client_args=dict(backend='disk')),
+                     dict(
+                         type='LoadPointsFromMultiSweeps',
+                         sweeps_num=10,
+                         file_client_args=dict(backend='disk')),
+                     dict(
+                         type='DefaultFormatBundle3D',
+                         class_names=[],
+                         with_label=False),
+                     dict(type='Collect3D', keys=['points'])
+                 ]):
         """Evaluation in nuScenes protocol.
 
         Args:
@@ -471,7 +487,7 @@ class NuScenesDataset(Custom3DDataset):
             out_dir (str): Path to save the visualization results.
                 Default: None.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: None.
+                Default: The eval_pipeline in dataset config file.
 
         Returns:
             dict[str, float]: Results of each evaluation metric.
@@ -494,7 +510,27 @@ class NuScenesDataset(Custom3DDataset):
             self.show(results, out_dir, pipeline=pipeline)
         return results_dict
 
-    def show(self, results, out_dir, show=True, pipeline=None):
+    def show(self,
+             results,
+             out_dir,
+             show=True,
+             pipeline=[
+                 dict(
+                     type='LoadPointsFromFile',
+                     coord_type='LIDAR',
+                     load_dim=5,
+                     use_dim=5,
+                     file_client_args=dict(backend='disk')),
+                 dict(
+                     type='LoadPointsFromMultiSweeps',
+                     sweeps_num=10,
+                     file_client_args=dict(backend='disk')),
+                 dict(
+                     type='DefaultFormatBundle3D',
+                     class_names=[],
+                     with_label=False),
+                 dict(type='Collect3D', keys=['points'])
+             ]):
         """Results visualization.
 
         Args:
@@ -502,23 +538,18 @@ class NuScenesDataset(Custom3DDataset):
             out_dir (str): Output directory of visualization result.
             show (bool): Visualize the results online.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: None.
+                Default: The eval_pipeline in dataset config file.
         """
         assert out_dir is not None, 'Expect out_dir, got none.'
-        if pipeline is not None:
-            pipeline = Compose(pipeline)
-            original_pipeline = self.pipeline if \
-                hasattr(self, 'pipeline') else None  # save the original one
-            self.pipeline = pipeline  # set new pipeline for data loading
+        pipeline = Compose(pipeline)
         for i, result in enumerate(results):
             if 'pts_bbox' in result.keys():
                 result = result['pts_bbox']
-            example = self.prepare_test_data(i)
             data_info = self.data_infos[i]
             pts_path = data_info['lidar_path']
             file_name = osp.split(pts_path)[-1].split('.')[0]
+            points = self._extract_data(i, pipeline, 'points').numpy()
             # for now we convert points into depth mode
-            points = self._extract_data(example, 'points').numpy()
             points = Coord3DMode.convert_point(points, Coord3DMode.LIDAR,
                                                Coord3DMode.DEPTH)
             inds = result['scores_3d'] > 0.1
@@ -530,11 +561,6 @@ class NuScenesDataset(Custom3DDataset):
                                                  Box3DMode.DEPTH)
             show_result(points, show_gt_bboxes, show_pred_bboxes, out_dir,
                         file_name, show)
-        if pipeline is not None:  # switch back to original pipeline
-            if original_pipeline is not None:
-                self.pipeline = original_pipeline
-            else:
-                delattr(self, 'pipeline')
 
 
 def output_to_nusc_box(detection):

--- a/mmdet3d/datasets/nuscenes_dataset.py
+++ b/mmdet3d/datasets/nuscenes_dataset.py
@@ -455,23 +455,7 @@ class NuScenesDataset(Custom3DDataset):
                  result_names=['pts_bbox'],
                  show=False,
                  out_dir=None,
-                 pipeline=[
-                     dict(
-                         type='LoadPointsFromFile',
-                         coord_type='LIDAR',
-                         load_dim=5,
-                         use_dim=5,
-                         file_client_args=dict(backend='disk')),
-                     dict(
-                         type='LoadPointsFromMultiSweeps',
-                         sweeps_num=10,
-                         file_client_args=dict(backend='disk')),
-                     dict(
-                         type='DefaultFormatBundle3D',
-                         class_names=[],
-                         with_label=False),
-                     dict(type='Collect3D', keys=['points'])
-                 ]):
+                 pipeline=None):
         """Evaluation in nuScenes protocol.
 
         Args:
@@ -487,7 +471,7 @@ class NuScenesDataset(Custom3DDataset):
             out_dir (str): Path to save the visualization results.
                 Default: None.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: The eval_pipeline in dataset config file.
+                Default: None.
 
         Returns:
             dict[str, float]: Results of each evaluation metric.
@@ -510,27 +494,28 @@ class NuScenesDataset(Custom3DDataset):
             self.show(results, out_dir, pipeline=pipeline)
         return results_dict
 
-    def show(self,
-             results,
-             out_dir,
-             show=True,
-             pipeline=[
-                 dict(
-                     type='LoadPointsFromFile',
-                     coord_type='LIDAR',
-                     load_dim=5,
-                     use_dim=5,
-                     file_client_args=dict(backend='disk')),
-                 dict(
-                     type='LoadPointsFromMultiSweeps',
-                     sweeps_num=10,
-                     file_client_args=dict(backend='disk')),
-                 dict(
-                     type='DefaultFormatBundle3D',
-                     class_names=[],
-                     with_label=False),
-                 dict(type='Collect3D', keys=['points'])
-             ]):
+    def _build_default_pipeline(self):
+        """Build the default pipeline for this dataset."""
+        pipeline = [
+            dict(
+                type='LoadPointsFromFile',
+                coord_type='LIDAR',
+                load_dim=5,
+                use_dim=5,
+                file_client_args=dict(backend='disk')),
+            dict(
+                type='LoadPointsFromMultiSweeps',
+                sweeps_num=10,
+                file_client_args=dict(backend='disk')),
+            dict(
+                type='DefaultFormatBundle3D',
+                class_names=self.CLASSES,
+                with_label=False),
+            dict(type='Collect3D', keys=['points'])
+        ]
+        return Compose(pipeline)
+
+    def show(self, results, out_dir, show=True, pipeline=None):
         """Results visualization.
 
         Args:
@@ -538,10 +523,10 @@ class NuScenesDataset(Custom3DDataset):
             out_dir (str): Output directory of visualization result.
             show (bool): Visualize the results online.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: The eval_pipeline in dataset config file.
+                Default: None.
         """
         assert out_dir is not None, 'Expect out_dir, got none.'
-        pipeline = Compose(pipeline)
+        pipeline = self._get_pipeline(pipeline)
         for i, result in enumerate(results):
             if 'pts_bbox' in result.keys():
                 result = result['pts_bbox']

--- a/mmdet3d/datasets/nuscenes_dataset.py
+++ b/mmdet3d/datasets/nuscenes_dataset.py
@@ -9,6 +9,7 @@ from mmdet.datasets import DATASETS
 from ..core import show_result
 from ..core.bbox import Box3DMode, Coord3DMode, LiDARInstance3DBoxes
 from .custom_3d import Custom3DDataset
+from .pipelines import Compose
 
 
 @DATASETS.register_module()
@@ -453,7 +454,8 @@ class NuScenesDataset(Custom3DDataset):
                  jsonfile_prefix=None,
                  result_names=['pts_bbox'],
                  show=False,
-                 out_dir=None):
+                 out_dir=None,
+                 pipeline=None):
         """Evaluation in nuScenes protocol.
 
         Args:
@@ -467,6 +469,8 @@ class NuScenesDataset(Custom3DDataset):
             show (bool): Whether to visualize.
                 Default: False.
             out_dir (str): Path to save the visualization results.
+                Default: None.
+            pipeline (list[dict], optional): raw data loading for showing.
                 Default: None.
 
         Returns:
@@ -487,33 +491,50 @@ class NuScenesDataset(Custom3DDataset):
             tmp_dir.cleanup()
 
         if show:
-            self.show(results, out_dir)
+            self.show(results, out_dir, pipeline=pipeline)
         return results_dict
 
-    def show(self, results, out_dir):
+    def show(self, results, out_dir, show=True, pipeline=None):
         """Results visualization.
 
         Args:
             results (list[dict]): List of bounding boxes results.
             out_dir (str): Output directory of visualization result.
+            show (bool): Visualize the results online.
+            pipeline (list[dict], optional): raw data loading for showing.
+                Default: None.
         """
+        assert out_dir is not None, 'Expect out_dir, got none.'
+        if pipeline is not None:
+            pipeline = Compose(pipeline)
+            original_pipeline = self.pipeline if \
+                hasattr(self, 'pipeline') else None  # save the original one
+            self.pipeline = pipeline  # set new pipeline for data loading
         for i, result in enumerate(results):
+            if 'pts_bbox' in result.keys():
+                result = result['pts_bbox']
             example = self.prepare_test_data(i)
-            points = example['points'][0]._data.numpy()
             data_info = self.data_infos[i]
             pts_path = data_info['lidar_path']
             file_name = osp.split(pts_path)[-1].split('.')[0]
             # for now we convert points into depth mode
+            points = self._extract_data(example, 'points').numpy()
             points = Coord3DMode.convert_point(points, Coord3DMode.LIDAR,
                                                Coord3DMode.DEPTH)
-            inds = result['pts_bbox']['scores_3d'] > 0.1
+            inds = result['scores_3d'] > 0.1
             gt_bboxes = self.get_ann_info(i)['gt_bboxes_3d'].tensor.numpy()
-            gt_bboxes = Box3DMode.convert(gt_bboxes, Box3DMode.LIDAR,
-                                          Box3DMode.DEPTH)
-            pred_bboxes = result['pts_bbox']['boxes_3d'][inds].tensor.numpy()
-            pred_bboxes = Box3DMode.convert(pred_bboxes, Box3DMode.LIDAR,
-                                            Box3DMode.DEPTH)
-            show_result(points, gt_bboxes, pred_bboxes, out_dir, file_name)
+            show_gt_bboxes = Box3DMode.convert(gt_bboxes, Box3DMode.LIDAR,
+                                               Box3DMode.DEPTH)
+            pred_bboxes = result['boxes_3d'][inds].tensor.numpy()
+            show_pred_bboxes = Box3DMode.convert(pred_bboxes, Box3DMode.LIDAR,
+                                                 Box3DMode.DEPTH)
+            show_result(points, show_gt_bboxes, show_pred_bboxes, out_dir,
+                        file_name, show)
+        if pipeline is not None:  # switch back to original pipeline
+            if original_pipeline is not None:
+                self.pipeline = original_pipeline
+            else:
+                delattr(self, 'pipeline')
 
 
 def output_to_nusc_box(detection):

--- a/mmdet3d/datasets/pipelines/__init__.py
+++ b/mmdet3d/datasets/pipelines/__init__.py
@@ -1,9 +1,10 @@
 from mmdet.datasets.pipelines import Compose
 from .dbsampler import DataBaseSampler
 from .formating import Collect3D, DefaultFormatBundle, DefaultFormatBundle3D
-from .loading import (LoadAnnotations3D, LoadMultiViewImageFromFiles,
-                      LoadPointsFromFile, LoadPointsFromMultiSweeps,
-                      NormalizePointsColor, PointSegClassMapping)
+from .loading import (LoadAnnotations3D, LoadImageFromFileMono3D,
+                      LoadMultiViewImageFromFiles, LoadPointsFromFile,
+                      LoadPointsFromMultiSweeps, NormalizePointsColor,
+                      PointSegClassMapping)
 from .test_time_aug import MultiScaleFlipAug3D
 from .transforms_3d import (BackgroundPointsFilter, GlobalRotScaleTrans,
                             IndoorPatchPointSample, IndoorPointSample,
@@ -19,5 +20,5 @@ __all__ = [
     'NormalizePointsColor', 'LoadAnnotations3D', 'IndoorPointSample',
     'PointSegClassMapping', 'MultiScaleFlipAug3D', 'LoadPointsFromMultiSweeps',
     'BackgroundPointsFilter', 'VoxelBasedPointSampler',
-    'IndoorPatchPointSample'
+    'IndoorPatchPointSample', 'LoadImageFromFileMono3D'
 ]

--- a/mmdet3d/datasets/scannet_dataset.py
+++ b/mmdet3d/datasets/scannet_dataset.py
@@ -109,23 +109,24 @@ class ScanNetDataset(Custom3DDataset):
             pts_semantic_mask_path=pts_semantic_mask_path)
         return anns_results
 
-    def show(self,
-             results,
-             out_dir,
-             show=True,
-             pipeline=[
-                 dict(
-                     type='LoadPointsFromFile',
-                     coord_type='DEPTH',
-                     shift_height=False,
-                     load_dim=6,
-                     use_dim=[0, 1, 2]),
-                 dict(
-                     type='DefaultFormatBundle3D',
-                     class_names=[],
-                     with_label=False),
-                 dict(type='Collect3D', keys=['points'])
-             ]):
+    def _build_default_pipeline(self):
+        """Build the default pipeline for this dataset."""
+        pipeline = [
+            dict(
+                type='LoadPointsFromFile',
+                coord_type='DEPTH',
+                shift_height=False,
+                load_dim=6,
+                use_dim=[0, 1, 2]),
+            dict(
+                type='DefaultFormatBundle3D',
+                class_names=self.CLASSES,
+                with_label=False),
+            dict(type='Collect3D', keys=['points'])
+        ]
+        return Compose(pipeline)
+
+    def show(self, results, out_dir, show=True, pipeline=None):
         """Results visualization.
 
         Args:
@@ -133,10 +134,10 @@ class ScanNetDataset(Custom3DDataset):
             out_dir (str): Output directory of visualization result.
             show (bool): Visualize the results online.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: The eval_pipeline in dataset config file.
+                Default: None.
         """
         assert out_dir is not None, 'Expect out_dir, got none.'
-        pipeline = Compose(pipeline)
+        pipeline = self._get_pipeline(pipeline)
         for i, result in enumerate(results):
             data_info = self.data_infos[i]
             pts_path = data_info['pts_path']
@@ -257,34 +258,35 @@ class ScanNetSegDataset(Custom3DSegDataset):
         anns_results = dict(pts_semantic_mask_path=pts_semantic_mask_path)
         return anns_results
 
-    def show(self,
-             results,
-             out_dir,
-             show=True,
-             pipeline=[
-                 dict(
-                     type='LoadPointsFromFile',
-                     coord_type='DEPTH',
-                     shift_height=False,
-                     use_color=True,
-                     load_dim=6,
-                     use_dim=[0, 1, 2, 3, 4, 5]),
-                 dict(
-                     type='LoadAnnotations3D',
-                     with_bbox_3d=False,
-                     with_label_3d=False,
-                     with_mask_3d=False,
-                     with_seg_3d=True),
-                 dict(
-                     type='PointSegClassMapping',
-                     valid_cat_ids=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14,
-                                    16, 24, 28, 33, 34, 36, 39)),
-                 dict(
-                     type='DefaultFormatBundle3D',
-                     with_label=False,
-                     class_names=[]),
-                 dict(type='Collect3D', keys=['points', 'pts_semantic_mask'])
-             ]):
+    def _build_default_pipeline(self):
+        """Build the default pipeline for this dataset."""
+        pipeline = [
+            dict(
+                type='LoadPointsFromFile',
+                coord_type='DEPTH',
+                shift_height=False,
+                use_color=True,
+                load_dim=6,
+                use_dim=[0, 1, 2, 3, 4, 5]),
+            dict(
+                type='LoadAnnotations3D',
+                with_bbox_3d=False,
+                with_label_3d=False,
+                with_mask_3d=False,
+                with_seg_3d=True),
+            dict(
+                type='PointSegClassMapping',
+                valid_cat_ids=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16,
+                               24, 28, 33, 34, 36, 39)),
+            dict(
+                type='DefaultFormatBundle3D',
+                with_label=False,
+                class_names=self.CLASSES),
+            dict(type='Collect3D', keys=['points', 'pts_semantic_mask'])
+        ]
+        return Compose(pipeline)
+
+    def show(self, results, out_dir, show=True, pipeline=None):
         """Results visualization.
 
         Args:
@@ -292,10 +294,10 @@ class ScanNetSegDataset(Custom3DSegDataset):
             out_dir (str): Output directory of visualization result.
             show (bool): Visualize the results online.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: The eval_pipeline in dataset config file.
+                Default: None.
         """
         assert out_dir is not None, 'Expect out_dir, got none.'
-        pipeline = Compose(pipeline)
+        pipeline = self._get_pipeline(pipeline)
         for i, result in enumerate(results):
             data_info = self.data_infos[i]
             pts_path = data_info['pts_path']

--- a/mmdet3d/datasets/sunrgbd_dataset.py
+++ b/mmdet3d/datasets/sunrgbd_dataset.py
@@ -154,35 +154,21 @@ class SUNRGBDDataset(Custom3DDataset):
 
     def _build_default_pipeline(self):
         """Build the default pipeline for this dataset."""
+        pipeline = [
+            dict(
+                type='LoadPointsFromFile',
+                coord_type='DEPTH',
+                shift_height=False,
+                load_dim=6,
+                use_dim=[0, 1, 2]),
+            dict(
+                type='DefaultFormatBundle3D',
+                class_names=self.CLASSES,
+                with_label=False),
+            dict(type='Collect3D', keys=['points'])
+        ]
         if self.modality['use_camera']:
-            pipeline = [
-                dict(type='LoadImageFromFile'),
-                dict(
-                    type='LoadPointsFromFile',
-                    coord_type='DEPTH',
-                    shift_height=False,
-                    load_dim=6,
-                    use_dim=[0, 1, 2]),
-                dict(
-                    type='DefaultFormatBundle3D',
-                    class_names=self.CLASSES,
-                    with_label=False),
-                dict(type='Collect3D', keys=['points', 'img'])
-            ]
-        else:
-            pipeline = [
-                dict(
-                    type='LoadPointsFromFile',
-                    coord_type='DEPTH',
-                    shift_height=False,
-                    load_dim=6,
-                    use_dim=[0, 1, 2]),
-                dict(
-                    type='DefaultFormatBundle3D',
-                    class_names=self.CLASSES,
-                    with_label=False),
-                dict(type='Collect3D', keys=['points'])
-            ]
+            pipeline.insert(0, dict(type='LoadImageFromFile'))
         return Compose(pipeline)
 
     def show(self, results, out_dir, show=True, pipeline=None):

--- a/mmdet3d/datasets/utils.py
+++ b/mmdet3d/datasets/utils.py
@@ -1,21 +1,59 @@
+# yapf: disable
 from mmdet3d.datasets.pipelines import (Collect3D, DefaultFormatBundle3D,
                                         LoadAnnotations3D,
+                                        LoadImageFromFileMono3D,
                                         LoadMultiViewImageFromFiles,
                                         LoadPointsFromFile,
-                                        LoadPointsFromMultiSweeps)
+                                        LoadPointsFromMultiSweeps,
+                                        MultiScaleFlipAug3D,
+                                        PointSegClassMapping)
+# yapf: enable
 from mmdet.datasets.builder import PIPELINES
 from mmdet.datasets.pipelines import LoadImageFromFile
+
+
+def is_loading_function(transform):
+    """Judge whether a transform function is a loading function.
+
+    Args:
+        transform (dict | :obj:`Pipeline`): A transform config or a function.
+
+    Returns:
+        bool | None: Whether it is a loading function. None means can't judge.
+            When transform is `MultiScaleFlipAug3D`, we return None.
+    """
+    # TODO: use more elegant way to distinguish loading modules
+    loading_functions = (LoadImageFromFile, LoadPointsFromFile,
+                         LoadAnnotations3D, LoadMultiViewImageFromFiles,
+                         LoadPointsFromMultiSweeps, DefaultFormatBundle3D,
+                         Collect3D, LoadImageFromFileMono3D,
+                         PointSegClassMapping)
+    if isinstance(transform, dict):
+        obj_cls = PIPELINES.get(transform['type'])
+        if obj_cls is None:
+            return False
+        if obj_cls in loading_functions:
+            return True
+        if obj_cls in (MultiScaleFlipAug3D):
+            return None
+    elif callable(transform):
+        if isinstance(transform, loading_functions):
+            return True
+        if isinstance(transform, MultiScaleFlipAug3D):
+            return None
+    return False
 
 
 def get_loading_pipeline(pipeline):
     """Only keep loading image, points and annotations related configuration.
 
     Args:
-        pipeline (list[dict]): Data pipeline configs.
+        pipeline (list[dict] | list[:obj:`Pipeline`]):
+            Data pipeline configs or list of pipeline functions.
 
     Returns:
-        list[dict]: The new pipeline list with only keep
-            loading image, points and annotations related configuration.
+        list[dict] | list[:obj:`Pipeline`]): The new pipeline list with only
+            keep loading image, points and annotations related configuration.
 
     Examples:
         >>> pipelines = [
@@ -51,16 +89,19 @@ def get_loading_pipeline(pipeline):
         >>> assert expected_pipelines ==\
         ...        get_loading_pipeline(pipelines)
     """
-    loading_pipeline_cfg = []
-    for cfg in pipeline:
-        obj_cls = PIPELINES.get(cfg['type'])
-        # TODO: use more elegant way to distinguish loading modules
-        if obj_cls is not None and obj_cls in (
-                LoadImageFromFile, LoadPointsFromFile, LoadAnnotations3D,
-                LoadMultiViewImageFromFiles, LoadPointsFromMultiSweeps,
-                DefaultFormatBundle3D, Collect3D):
-            loading_pipeline_cfg.append(cfg)
-    assert len(loading_pipeline_cfg) > 0, \
+    loading_pipeline = []
+    for transform in pipeline:
+        is_loading = is_loading_function(transform)
+        if is_loading is None:  # MultiScaleFlipAug3D
+            # extract its inner pipeline
+            if isinstance(transform, dict):
+                inner_pipeline = transform.get('transforms', [])
+            else:
+                inner_pipeline = transform.transforms.transforms
+            loading_pipeline.extend(get_loading_pipeline(inner_pipeline))
+        elif is_loading:
+            loading_pipeline.append(transform)
+    assert len(loading_pipeline) > 0, \
         'The data pipeline in your config file must include ' \
         'loading step.'
-    return loading_pipeline_cfg
+    return loading_pipeline

--- a/mmdet3d/datasets/waymo_dataset.py
+++ b/mmdet3d/datasets/waymo_dataset.py
@@ -219,7 +219,8 @@ class WaymoDataset(KittiDataset):
                  pklfile_prefix=None,
                  submission_prefix=None,
                  show=False,
-                 out_dir=None):
+                 out_dir=None,
+                 pipeline=None):
         """Evaluation in KITTI protocol.
 
         Args:
@@ -236,6 +237,8 @@ class WaymoDataset(KittiDataset):
             show (bool): Whether to visualize.
                 Default: False.
             out_dir (str): Path to save the visualization results.
+                Default: None.
+            pipeline (list[dict], optional): raw data loading for showing.
                 Default: None.
 
         Returns:
@@ -346,7 +349,7 @@ class WaymoDataset(KittiDataset):
             tmp_dir.cleanup()
 
         if show:
-            self.show(results, out_dir)
+            self.show(results, out_dir, pipeline=pipeline)
         return ap_dict
 
     def bbox2result_kitti(self,

--- a/mmdet3d/datasets/waymo_dataset.py
+++ b/mmdet3d/datasets/waymo_dataset.py
@@ -220,19 +220,7 @@ class WaymoDataset(KittiDataset):
                  submission_prefix=None,
                  show=False,
                  out_dir=None,
-                 pipeline=[
-                     dict(
-                         type='LoadPointsFromFile',
-                         coord_type='LIDAR',
-                         load_dim=6,
-                         use_dim=5,
-                         file_client_args=dict(backend='disk')),
-                     dict(
-                         type='DefaultFormatBundle3D',
-                         class_names=[],
-                         with_label=False),
-                     dict(type='Collect3D', keys=['points'])
-                 ]):
+                 pipeline=None):
         """Evaluation in KITTI protocol.
 
         Args:
@@ -251,7 +239,7 @@ class WaymoDataset(KittiDataset):
             out_dir (str): Path to save the visualization results.
                 Default: None.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: The eval_pipeline in dataset config file.
+                Default: None.
 
         Returns:
             dict[str: float]: results of each evaluation metric

--- a/mmdet3d/datasets/waymo_dataset.py
+++ b/mmdet3d/datasets/waymo_dataset.py
@@ -220,7 +220,19 @@ class WaymoDataset(KittiDataset):
                  submission_prefix=None,
                  show=False,
                  out_dir=None,
-                 pipeline=None):
+                 pipeline=[
+                     dict(
+                         type='LoadPointsFromFile',
+                         coord_type='LIDAR',
+                         load_dim=6,
+                         use_dim=5,
+                         file_client_args=dict(backend='disk')),
+                     dict(
+                         type='DefaultFormatBundle3D',
+                         class_names=[],
+                         with_label=False),
+                     dict(type='Collect3D', keys=['points'])
+                 ]):
         """Evaluation in KITTI protocol.
 
         Args:
@@ -239,7 +251,7 @@ class WaymoDataset(KittiDataset):
             out_dir (str): Path to save the visualization results.
                 Default: None.
             pipeline (list[dict], optional): raw data loading for showing.
-                Default: None.
+                Default: The eval_pipeline in dataset config file.
 
         Returns:
             dict[str: float]: results of each evaluation metric

--- a/tests/test_data/test_datasets/test_kitti_dataset.py
+++ b/tests/test_data/test_datasets/test_kitti_dataset.py
@@ -292,7 +292,7 @@ def test_show():
         _generate_kitti_multi_modality_dataset_config()
     kitti_dataset = KittiDataset(data_root, ann_file, split, pts_prefix,
                                  multi_modality_pipeline, classes, modality)
-    kitti_dataset.show(results, temp_dir, False, multi_modality_pipeline)
+    kitti_dataset.show(results, temp_dir, show=False)
     pts_file_path = osp.join(temp_dir, '000000', '000000_points.obj')
     gt_file_path = osp.join(temp_dir, '000000', '000000_gt.obj')
     pred_file_path = osp.join(temp_dir, '000000', '000000_pred.obj')

--- a/tests/test_data/test_datasets/test_kitti_dataset.py
+++ b/tests/test_data/test_datasets/test_kitti_dataset.py
@@ -261,6 +261,30 @@ def test_show():
     mmcv.check_file_exist(pred_file_path)
     tmp_dir.cleanup()
 
+    # test show with pipeline
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='LIDAR',
+            load_dim=4,
+            use_dim=4),
+        dict(
+            type='DefaultFormatBundle3D',
+            class_names=classes,
+            with_label=False),
+        dict(type='Collect3D', keys=['points'])
+    ]
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    kitti_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
+    pts_file_path = osp.join(temp_dir, '000000', '000000_points.obj')
+    gt_file_path = osp.join(temp_dir, '000000', '000000_gt.obj')
+    pred_file_path = osp.join(temp_dir, '000000', '000000_pred.obj')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    tmp_dir.cleanup()
+
     # test multi-modality show
     tmp_dir = tempfile.TemporaryDirectory()
     temp_dir = tmp_dir.name
@@ -269,6 +293,37 @@ def test_show():
     kitti_dataset = KittiDataset(data_root, ann_file, split, pts_prefix,
                                  multi_modality_pipeline, classes, modality)
     kitti_dataset.show(results, temp_dir, show=False)
+    pts_file_path = osp.join(temp_dir, '000000', '000000_points.obj')
+    gt_file_path = osp.join(temp_dir, '000000', '000000_gt.obj')
+    pred_file_path = osp.join(temp_dir, '000000', '000000_pred.obj')
+    img_file_path = osp.join(temp_dir, '000000', '000000_img.png')
+    img_pred_path = osp.join(temp_dir, '000000', '000000_pred.png')
+    img_gt_file = osp.join(temp_dir, '000000', '000000_gt.png')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    mmcv.check_file_exist(img_file_path)
+    mmcv.check_file_exist(img_pred_path)
+    mmcv.check_file_exist(img_gt_file)
+    tmp_dir.cleanup()
+
+    # test multi-modality show with pipeline
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='LIDAR',
+            load_dim=4,
+            use_dim=4),
+        dict(type='LoadImageFromFile'),
+        dict(
+            type='DefaultFormatBundle3D',
+            class_names=classes,
+            with_label=False),
+        dict(type='Collect3D', keys=['points', 'img'])
+    ]
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    kitti_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
     pts_file_path = osp.join(temp_dir, '000000', '000000_points.obj')
     gt_file_path = osp.join(temp_dir, '000000', '000000_gt.obj')
     pred_file_path = osp.join(temp_dir, '000000', '000000_pred.obj')

--- a/tests/test_data/test_datasets/test_kitti_dataset.py
+++ b/tests/test_data/test_datasets/test_kitti_dataset.py
@@ -292,7 +292,7 @@ def test_show():
         _generate_kitti_multi_modality_dataset_config()
     kitti_dataset = KittiDataset(data_root, ann_file, split, pts_prefix,
                                  multi_modality_pipeline, classes, modality)
-    kitti_dataset.show(results, temp_dir, show=False)
+    kitti_dataset.show(results, temp_dir, False, multi_modality_pipeline)
     pts_file_path = osp.join(temp_dir, '000000', '000000_points.obj')
     gt_file_path = osp.join(temp_dir, '000000', '000000_gt.obj')
     pred_file_path = osp.join(temp_dir, '000000', '000000_pred.obj')

--- a/tests/test_data/test_datasets/test_lyft_dataset.py
+++ b/tests/test_data/test_datasets/test_lyft_dataset.py
@@ -156,7 +156,7 @@ def test_show():
     scores_3d = torch.tensor([0.1815, 0.1663, 0.5792, 0.2194, 0.2780])
     labels_3d = torch.tensor([0, 0, 1, 1, 2])
     result = dict(boxes_3d=boxes_3d, scores_3d=scores_3d, labels_3d=labels_3d)
-    results = [result]
+    results = [dict(pts_bbox=result)]
     kitti_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
     file_name = 'host-a017_lidar1_1236118886901125926'
     pts_file_path = osp.join(temp_dir, file_name, f'{file_name}_points.obj')

--- a/tests/test_data/test_datasets/test_lyft_dataset.py
+++ b/tests/test_data/test_datasets/test_lyft_dataset.py
@@ -1,5 +1,6 @@
 import mmcv
 import numpy as np
+import tempfile
 import torch
 
 from mmdet3d.datasets import LyftDataset
@@ -114,3 +115,54 @@ def test_evaluate():
     ap_dict = lyft_dataset.evaluate(results, 'bbox')
     car_precision = ap_dict['pts_bbox_Lyft/car_AP']
     assert car_precision == 0.6
+
+
+def test_show():
+    import mmcv
+    from os import path as osp
+
+    from mmdet3d.core.bbox import LiDARInstance3DBoxes
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    root_path = './tests/data/lyft'
+    ann_file = './tests/data/lyft/lyft_infos.pkl'
+    class_names = ('car', 'truck', 'bus', 'emergency_vehicle', 'other_vehicle',
+                   'motorcycle', 'bicycle', 'pedestrian', 'animal')
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='LIDAR',
+            load_dim=5,
+            use_dim=5,
+            file_client_args=dict(backend='disk')),
+        dict(
+            type='LoadPointsFromMultiSweeps',
+            sweeps_num=10,
+            file_client_args=dict(backend='disk')),
+        dict(
+            type='DefaultFormatBundle3D',
+            class_names=class_names,
+            with_label=False),
+        dict(type='Collect3D', keys=['points'])
+    ]
+    kitti_dataset = LyftDataset(ann_file, None, root_path)
+    boxes_3d = LiDARInstance3DBoxes(
+        torch.tensor(
+            [[46.1218, -4.6496, -0.9275, 0.5316, 1.4442, 1.7450, 1.1749],
+             [33.3189, 0.1981, 0.3136, 0.5656, 1.2301, 1.7985, 1.5723],
+             [46.1366, -4.6404, -0.9510, 0.5162, 1.6501, 1.7540, 1.3778],
+             [33.2646, 0.2297, 0.3446, 0.5746, 1.3365, 1.7947, 1.5430],
+             [58.9079, 16.6272, -1.5829, 1.5656, 3.9313, 1.4899, 1.5505]]))
+    scores_3d = torch.tensor([0.1815, 0.1663, 0.5792, 0.2194, 0.2780])
+    labels_3d = torch.tensor([0, 0, 1, 1, 2])
+    result = dict(boxes_3d=boxes_3d, scores_3d=scores_3d, labels_3d=labels_3d)
+    results = [result]
+    kitti_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
+    file_name = 'host-a017_lidar1_1236118886901125926'
+    pts_file_path = osp.join(temp_dir, file_name, f'{file_name}_points.obj')
+    gt_file_path = osp.join(temp_dir, file_name, f'{file_name}_gt.obj')
+    pred_file_path = osp.join(temp_dir, file_name, f'{file_name}_pred.obj')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    tmp_dir.cleanup()

--- a/tests/test_data/test_datasets/test_nuscene_dataset.py
+++ b/tests/test_data/test_datasets/test_nuscene_dataset.py
@@ -1,4 +1,6 @@
 import numpy as np
+import tempfile
+import torch
 
 from mmdet3d.datasets import NuScenesDataset
 
@@ -59,3 +61,55 @@ def test_getitem():
     assert data['img_metas'][0].data['flip'] is False
     assert data['img_metas'][0].data['pcd_horizontal_flip'] is False
     assert data['points'][0]._data.shape == (597, 4)
+
+
+def test_show():
+    import mmcv
+    from os import path as osp
+
+    from mmdet3d.core.bbox import LiDARInstance3DBoxes
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    class_names = [
+        'car', 'truck', 'trailer', 'bus', 'construction_vehicle', 'bicycle',
+        'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'
+    ]
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='LIDAR',
+            load_dim=5,
+            use_dim=5,
+            file_client_args=dict(backend='disk')),
+        dict(
+            type='LoadPointsFromMultiSweeps',
+            sweeps_num=10,
+            file_client_args=dict(backend='disk')),
+        dict(
+            type='DefaultFormatBundle3D',
+            class_names=class_names,
+            with_label=False),
+        dict(type='Collect3D', keys=['points'])
+    ]
+    nus_dataset = NuScenesDataset('tests/data/nuscenes/nus_info.pkl', None,
+                                  'tests/data/nuscenes')
+    boxes_3d = LiDARInstance3DBoxes(
+        torch.tensor(
+            [[46.1218, -4.6496, -0.9275, 0.5316, 1.4442, 1.7450, 1.1749],
+             [33.3189, 0.1981, 0.3136, 0.5656, 1.2301, 1.7985, 1.5723],
+             [46.1366, -4.6404, -0.9510, 0.5162, 1.6501, 1.7540, 1.3778],
+             [33.2646, 0.2297, 0.3446, 0.5746, 1.3365, 1.7947, 1.5430],
+             [58.9079, 16.6272, -1.5829, 1.5656, 3.9313, 1.4899, 1.5505]]))
+    scores_3d = torch.tensor([0.1815, 0.1663, 0.5792, 0.2194, 0.2780])
+    labels_3d = torch.tensor([0, 0, 1, 1, 2])
+    result = dict(boxes_3d=boxes_3d, scores_3d=scores_3d, labels_3d=labels_3d)
+    results = [dict(pts_bbox=result)]
+    nus_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
+    file_name = 'n015-2018-08-02-17-16-37+0800__LIDAR_TOP__1533201470948018'
+    pts_file_path = osp.join(temp_dir, file_name, f'{file_name}_points.obj')
+    gt_file_path = osp.join(temp_dir, file_name, f'{file_name}_gt.obj')
+    pred_file_path = osp.join(temp_dir, file_name, f'{file_name}_pred.obj')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    tmp_dir.cleanup()

--- a/tests/test_data/test_datasets/test_scannet_dataset.py
+++ b/tests/test_data/test_datasets/test_scannet_dataset.py
@@ -214,6 +214,37 @@ def test_show():
     mmcv.check_file_exist(pred_file_path)
     tmp_dir.cleanup()
 
+    # show function with pipeline
+    class_names = ('cabinet', 'bed', 'chair', 'sofa', 'table', 'door',
+                   'window', 'bookshelf', 'picture', 'counter', 'desk',
+                   'curtain', 'refrigerator', 'showercurtrain', 'toilet',
+                   'sink', 'bathtub', 'garbagebin')
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='DEPTH',
+            shift_height=False,
+            load_dim=6,
+            use_dim=[0, 1, 2]),
+        dict(
+            type='DefaultFormatBundle3D',
+            class_names=class_names,
+            with_label=False),
+        dict(type='Collect3D', keys=['points'])
+    ]
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    scannet_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
+    pts_file_path = osp.join(temp_dir, 'scene0000_00',
+                             'scene0000_00_points.obj')
+    gt_file_path = osp.join(temp_dir, 'scene0000_00', 'scene0000_00_gt.obj')
+    pred_file_path = osp.join(temp_dir, 'scene0000_00',
+                              'scene0000_00_pred.obj')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    tmp_dir.cleanup()
+
 
 def test_seg_getitem():
     np.random.seed(0)

--- a/tests/test_data/test_datasets/test_scannet_dataset.py
+++ b/tests/test_data/test_datasets/test_scannet_dataset.py
@@ -525,6 +525,37 @@ def test_seg_evaluate():
     assert abs(ret_dict['acc'] - 0.8219) < 0.01
     assert abs(ret_dict['acc_cls'] - 0.7649) < 0.01
 
+    # test evaluate with pipeline
+    class_names = ('wall', 'floor', 'cabinet', 'bed', 'chair', 'sofa', 'table',
+                   'door', 'window', 'bookshelf', 'picture', 'counter', 'desk',
+                   'curtain', 'refrigerator', 'showercurtrain', 'toilet',
+                   'sink', 'bathtub', 'otherfurniture')
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='DEPTH',
+            shift_height=False,
+            use_color=True,
+            load_dim=6,
+            use_dim=[0, 1, 2, 3, 4, 5]),
+        dict(
+            type='LoadAnnotations3D',
+            with_bbox_3d=False,
+            with_label_3d=False,
+            with_mask_3d=False,
+            with_seg_3d=True),
+        dict(
+            type='PointSegClassMapping',
+            valid_cat_ids=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 24,
+                           28, 33, 34, 36, 39)),
+        dict(type='DefaultFormatBundle3D', class_names=class_names),
+        dict(type='Collect3D', keys=['points', 'pts_semantic_mask'])
+    ]
+    ret_dict = scannet_dataset.evaluate(results, pipeline=eval_pipeline)
+    assert abs(ret_dict['miou'] - 0.5308) < 0.01
+    assert abs(ret_dict['acc'] - 0.8219) < 0.01
+    assert abs(ret_dict['acc_cls'] - 0.7649) < 0.01
+
 
 def test_seg_show():
     import mmcv
@@ -547,6 +578,44 @@ def test_seg_show():
         ]).long())
     results = [result]
     scannet_dataset.show(results, temp_dir, show=False)
+    pts_file_path = osp.join(temp_dir, 'scene0000_00',
+                             'scene0000_00_points.obj')
+    gt_file_path = osp.join(temp_dir, 'scene0000_00', 'scene0000_00_gt.obj')
+    pred_file_path = osp.join(temp_dir, 'scene0000_00',
+                              'scene0000_00_pred.obj')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    tmp_dir.cleanup()
+    # test show with pipeline
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    class_names = ('wall', 'floor', 'cabinet', 'bed', 'chair', 'sofa', 'table',
+                   'door', 'window', 'bookshelf', 'picture', 'counter', 'desk',
+                   'curtain', 'refrigerator', 'showercurtrain', 'toilet',
+                   'sink', 'bathtub', 'otherfurniture')
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='DEPTH',
+            shift_height=False,
+            use_color=True,
+            load_dim=6,
+            use_dim=[0, 1, 2, 3, 4, 5]),
+        dict(
+            type='LoadAnnotations3D',
+            with_bbox_3d=False,
+            with_label_3d=False,
+            with_mask_3d=False,
+            with_seg_3d=True),
+        dict(
+            type='PointSegClassMapping',
+            valid_cat_ids=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 24,
+                           28, 33, 34, 36, 39)),
+        dict(type='DefaultFormatBundle3D', class_names=class_names),
+        dict(type='Collect3D', keys=['points', 'pts_semantic_mask'])
+    ]
+    scannet_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
     pts_file_path = osp.join(temp_dir, 'scene0000_00',
                              'scene0000_00_points.obj')
     gt_file_path = osp.join(temp_dir, 'scene0000_00', 'scene0000_00_gt.obj')
@@ -588,4 +657,3 @@ def test_seg_format_results():
     expected_txt_path = osp.join(tmp_dir.name, 'results', 'scene0000_00.txt')
     assert np.all(result_files[0]['seg_mask'] == expected_label)
     mmcv.check_file_exist(expected_txt_path)
-    tmp_dir.cleanup()

--- a/tests/test_data/test_datasets/test_scannet_dataset.py
+++ b/tests/test_data/test_datasets/test_scannet_dataset.py
@@ -520,12 +520,7 @@ def test_seg_evaluate():
             13, 2, 3, 1, 0, 13, 19, 1, 14, 5, 3, 1, 13, 1, 2, 3, 2, 1
         ]).long())
     results.append(pred_sem_mask)
-    ret_dict = scannet_dataset.evaluate(results)
-    assert abs(ret_dict['miou'] - 0.5308) < 0.01
-    assert abs(ret_dict['acc'] - 0.8219) < 0.01
-    assert abs(ret_dict['acc_cls'] - 0.7649) < 0.01
 
-    # test evaluate with pipeline
     class_names = ('wall', 'floor', 'cabinet', 'bed', 'chair', 'sofa', 'table',
                    'door', 'window', 'bookshelf', 'picture', 'counter', 'desk',
                    'curtain', 'refrigerator', 'showercurtrain', 'toilet',

--- a/tests/test_data/test_datasets/test_sunrgbd_dataset.py
+++ b/tests/test_data/test_datasets/test_sunrgbd_dataset.py
@@ -267,7 +267,7 @@ def test_show():
         _generate_sunrgbd_multi_modality_dataset_config()
     sunrgbd_dataset = SUNRGBDDataset(
         root_path, ann_file, multi_modality_pipelines, modality=modality)
-    sunrgbd_dataset.show(results, temp_dir, show=False)
+    sunrgbd_dataset.show(results, temp_dir, False, multi_modality_pipelines)
     pts_file_path = osp.join(temp_dir, '000001', '000001_points.obj')
     gt_file_path = osp.join(temp_dir, '000001', '000001_gt.obj')
     pred_file_path = osp.join(temp_dir, '000001', '000001_pred.obj')

--- a/tests/test_data/test_datasets/test_sunrgbd_dataset.py
+++ b/tests/test_data/test_datasets/test_sunrgbd_dataset.py
@@ -267,7 +267,7 @@ def test_show():
         _generate_sunrgbd_multi_modality_dataset_config()
     sunrgbd_dataset = SUNRGBDDataset(
         root_path, ann_file, multi_modality_pipelines, modality=modality)
-    sunrgbd_dataset.show(results, temp_dir, False, multi_modality_pipelines)
+    sunrgbd_dataset.show(results, temp_dir, show=False)
     pts_file_path = osp.join(temp_dir, '000001', '000001_points.obj')
     gt_file_path = osp.join(temp_dir, '000001', '000001_gt.obj')
     pred_file_path = osp.join(temp_dir, '000001', '000001_pred.obj')

--- a/tests/test_data/test_datasets/test_sunrgbd_dataset.py
+++ b/tests/test_data/test_datasets/test_sunrgbd_dataset.py
@@ -210,7 +210,7 @@ def test_show():
     from mmdet3d.core.bbox import DepthInstance3DBoxes
     tmp_dir = tempfile.TemporaryDirectory()
     temp_dir = tmp_dir.name
-    root_path, ann_file, _, pipelines, modality = \
+    root_path, ann_file, class_names, pipelines, modality = \
         _generate_sunrgbd_dataset_config()
     sunrgbd_dataset = SUNRGBDDataset(
         root_path, ann_file, pipelines, modality=modality)
@@ -235,14 +235,71 @@ def test_show():
     mmcv.check_file_exist(pred_file_path)
     tmp_dir.cleanup()
 
+    # test show with pipeline
+    eval_pipeline = [
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='DEPTH',
+            shift_height=True,
+            load_dim=6,
+            use_dim=[0, 1, 2]),
+        dict(
+            type='DefaultFormatBundle3D',
+            class_names=class_names,
+            with_label=False),
+        dict(type='Collect3D', keys=['points'])
+    ]
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    sunrgbd_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
+    pts_file_path = osp.join(temp_dir, '000001', '000001_points.obj')
+    gt_file_path = osp.join(temp_dir, '000001', '000001_gt.obj')
+    pred_file_path = osp.join(temp_dir, '000001', '000001_pred.obj')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    tmp_dir.cleanup()
+
     # test multi-modality show
     tmp_dir = tempfile.TemporaryDirectory()
     temp_dir = tmp_dir.name
-    root_path, ann_file, _, multi_modality_pipelines, modality = \
+    root_path, ann_file, class_names, multi_modality_pipelines, modality = \
         _generate_sunrgbd_multi_modality_dataset_config()
     sunrgbd_dataset = SUNRGBDDataset(
         root_path, ann_file, multi_modality_pipelines, modality=modality)
     sunrgbd_dataset.show(results, temp_dir, show=False)
+    pts_file_path = osp.join(temp_dir, '000001', '000001_points.obj')
+    gt_file_path = osp.join(temp_dir, '000001', '000001_gt.obj')
+    pred_file_path = osp.join(temp_dir, '000001', '000001_pred.obj')
+    img_file_path = osp.join(temp_dir, '000001', '000001_img.png')
+    img_pred_path = osp.join(temp_dir, '000001', '000001_pred.png')
+    img_gt_file = osp.join(temp_dir, '000001', '000001_gt.png')
+    mmcv.check_file_exist(pts_file_path)
+    mmcv.check_file_exist(gt_file_path)
+    mmcv.check_file_exist(pred_file_path)
+    mmcv.check_file_exist(img_file_path)
+    mmcv.check_file_exist(img_pred_path)
+    mmcv.check_file_exist(img_gt_file)
+    tmp_dir.cleanup()
+
+    # test multi-modality show with pipeline
+    eval_pipeline = [
+        dict(type='LoadImageFromFile'),
+        dict(
+            type='LoadPointsFromFile',
+            coord_type='DEPTH',
+            shift_height=True,
+            load_dim=6,
+            use_dim=[0, 1, 2]),
+        dict(
+            type='DefaultFormatBundle3D',
+            class_names=class_names,
+            with_label=False),
+        dict(type='Collect3D', keys=['points', 'img', 'calib'])
+    ]
+    tmp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tmp_dir.name
+    sunrgbd_dataset.show(results, temp_dir, show=False, pipeline=eval_pipeline)
     pts_file_path = osp.join(temp_dir, '000001', '000001_points.obj')
     gt_file_path = osp.join(temp_dir, '000001', '000001_gt.obj')
     pred_file_path = osp.join(temp_dir, '000001', '000001_pred.obj')

--- a/tools/misc/visualize_results.py
+++ b/tools/misc/visualize_results.py
@@ -32,7 +32,12 @@ def main():
     results = mmcv.load(args.result)
 
     if getattr(dataset, 'show', None) is not None:
-        dataset.show(results, args.show_dir)
+        # data loading pipeline for showing
+        eval_pipeline = cfg.get('eval_pipeline', {})
+        if eval_pipeline:
+            dataset.show(results, args.show_dir, pipeline=eval_pipeline)
+        else:
+            dataset.show(results, args.show_dir)  # use default pipeline
     else:
         raise NotImplementedError(
             'Show is not implemented for dataset {}!'.format(


### PR DESCRIPTION
Fix [issue#412](https://github.com/open-mmlab/mmdetection3d/issues/412).

In dataset.show/evaluate() functions, we may need to load points/gt. In current implementations, we load them from disk using ```np.fromfile()```, which is incompatible when data is in ceph. To solve this, we add ```eval_pipeline``` in configs, and pass it as an argument to these functions. This pipeline purely consists of raw data loading operations (e.g. LoadImage, LoadPoints), eliminating the effects of data augmentation, and can adjust with the file client.