### PR TITLE
[Fix] #448 Clamp 3D votes projections to image boundaries

### DIFF
--- a/mmdet3d/models/fusion_layers/vote_fusion.py
+++ b/mmdet3d/models/fusion_layers/vote_fusion.py
@@ -196,8 +196,10 @@ class VoteFusion(nn.Module):
             img_flatten /= 255.
 
             # take the normalized pixel value as texture cue
-            uv_rescaled[:, 0] = torch.clamp(uv_rescaled[:, 0].round(), 0, img_shape[1] - 1)
-            uv_rescaled[:, 1] = torch.clamp(uv_rescaled[:, 1].round(), 0, img_shape[0] - 1)
+            uv_rescaled[:, 0] = torch.clamp(uv_rescaled[:, 0].round(), \
+                0, img_shape[1] - 1)
+            uv_rescaled[:, 1] = torch.clamp(uv_rescaled[:, 1].round(), \
+                0, img_shape[0] - 1)
             uv_flatten = uv_rescaled[:, 1].round() * \
                 img_shape[1] + uv_rescaled[:, 0].round()
             uv_expanded = uv_flatten.unsqueeze(0).expand(3, -1).long()

--- a/mmdet3d/models/fusion_layers/vote_fusion.py
+++ b/mmdet3d/models/fusion_layers/vote_fusion.py
@@ -196,10 +196,10 @@ class VoteFusion(nn.Module):
             img_flatten /= 255.
 
             # take the normalized pixel value as texture cue
-            uv_rescaled[:, 0] = torch.clamp(uv_rescaled[:, 0].round(),
-                                            0, img_shape[1] - 1)
-            uv_rescaled[:, 1] = torch.clamp(uv_rescaled[:, 1].round(),
-                                            0, img_shape[0] - 1)
+            uv_rescaled[:, 0] = torch.clamp(uv_rescaled[:, 0].round(), 0,
+                                            img_shape[1] - 1)
+            uv_rescaled[:, 1] = torch.clamp(uv_rescaled[:, 1].round(), 0,
+                                            img_shape[0] - 1)
             uv_flatten = uv_rescaled[:, 1].round() * \
                 img_shape[1] + uv_rescaled[:, 0].round()
             uv_expanded = uv_flatten.unsqueeze(0).expand(3, -1).long()

--- a/mmdet3d/models/fusion_layers/vote_fusion.py
+++ b/mmdet3d/models/fusion_layers/vote_fusion.py
@@ -196,6 +196,8 @@ class VoteFusion(nn.Module):
             img_flatten /= 255.
 
             # take the normalized pixel value as texture cue
+            uv_rescaled[:, 0] = torch.clamp(uv_rescaled[:, 0].round(), 0, img_shape[1] - 1)
+            uv_rescaled[:, 1] = torch.clamp(uv_rescaled[:, 1].round(), 0, img_shape[0] - 1)
             uv_flatten = uv_rescaled[:, 1].round() * \
                 img_shape[1] + uv_rescaled[:, 0].round()
             uv_expanded = uv_flatten.unsqueeze(0).expand(3, -1).long()

--- a/mmdet3d/models/fusion_layers/vote_fusion.py
+++ b/mmdet3d/models/fusion_layers/vote_fusion.py
@@ -196,10 +196,10 @@ class VoteFusion(nn.Module):
             img_flatten /= 255.
 
             # take the normalized pixel value as texture cue
-            uv_rescaled[:, 0] = torch.clamp(uv_rescaled[:, 0].round(), \
-                0, img_shape[1] - 1)
-            uv_rescaled[:, 1] = torch.clamp(uv_rescaled[:, 1].round(), \
-                0, img_shape[0] - 1)
+            uv_rescaled[:, 0] = torch.clamp(uv_rescaled[:, 0].round(),
+                                            0, img_shape[1] - 1)
+            uv_rescaled[:, 1] = torch.clamp(uv_rescaled[:, 1].round(),
+                                            0, img_shape[0] - 1)
             uv_flatten = uv_rescaled[:, 1].round() * \
                 img_shape[1] + uv_rescaled[:, 0].round()
             uv_expanded = uv_flatten.unsqueeze(0).expand(3, -1).long()


### PR DESCRIPTION
Fix issue #448:

- Projection of 3D seed points to image sometimes results in out-of-range image indices (by 1 or 2 pixels)
- Clamp the image indices to be within bounds