### PR TITLE
[Fix] Fix the origin setting when inference with FCOS3D head

### DIFF
--- a/mmdet3d/models/dense_heads/fcos_mono3d_head.py
+++ b/mmdet3d/models/dense_heads/fcos_mono3d_head.py
@@ -678,10 +678,12 @@ class FCOSMono3DHead(AnchorFreeMono3DHead):
                                        mlvl_attr_scores)
         bboxes, scores, labels, dir_scores, attrs = results
         attrs = attrs.to(labels.dtype)  # change data type to int
-        bboxes = input_meta['box_type_3d'](bboxes, box_dim=self.bbox_code_size)
+        bboxes = input_meta['box_type_3d'](
+            bboxes, box_dim=self.bbox_code_size, origin=(0.5, 0.5, 0.5))
         # Note that the predictions use origin (0.5, 0.5, 0.5)
         # Due to the ground truth centers2d are the gravity center of objects
-        # The center has been transformed when computing bev bbox!!!!
+        # v0.10.0 fix inplace operation to the input tensor of cam_box3d
+        # So here we also need to add origin=(0.5, 0.5, 0.5)
         if not self.pred_attrs:
             attrs = None
 


### PR DESCRIPTION
Due to #283 fixing the inplace operation when adjusting the origin of 3D boxes, initializing CameraInstance3DBoxes will not change the input tensor for center. So we need to input the origin setting (0.5, 0.5, 0.5) again when initializing the 3D boxes at the modified code.