### PR TITLE
[Fix] Typos in .gitignore & error in customize_runtime docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,8 +123,8 @@ exps/
 # demo
 *.jpg
 *.png
-/data/s3dis/Stanford3dDataset_v1.2_Aligned_Version/
-/data/scannet/scans/
-/data/sunrgbd/OFFICIAL_SUNRGBD/
+data/s3dis/Stanford3dDataset_v1.2_Aligned_Version/
+data/scannet/scans/
+data/sunrgbd/OFFICIAL_SUNRGBD/
 *.obj
 *.ply

--- a/README.md
+++ b/README.md
@@ -148,4 +148,5 @@ We wish that the toolbox and benchmark could serve the growing research communit
 - [MMTracking](https://github.com/open-mmlab/mmtracking): OpenMMLab video perception toolbox and benchmark.
 - [MMPose](https://github.com/open-mmlab/mmpose): OpenMMLab pose estimation toolbox and benchmark.
 - [MMEditing](https://github.com/open-mmlab/mmediting): OpenMMLab image and video editing toolbox.
+- [MMOCR](https://github.com/open-mmlab/mmocr): OpenMMLab text detection, recognition and understanding toolbox.
 - [MMGeneration](https://github.com/open-mmlab/mmgeneration): OpenMMLab image and video generative models toolbox.

--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ We wish that the toolbox and benchmark could serve the growing research communit
 - [MMTracking](https://github.com/open-mmlab/mmtracking): OpenMMLab video perception toolbox and benchmark.
 - [MMPose](https://github.com/open-mmlab/mmpose): OpenMMLab pose estimation toolbox and benchmark.
 - [MMEditing](https://github.com/open-mmlab/mmediting): OpenMMLab image and video editing toolbox.
-- [MMGeneration](https://github.com/open-mmlab/mmgeneration): A powerful toolkit for generative models.
+- [MMGeneration](https://github.com/open-mmlab/mmgeneration): OpenMMLab image and video generative models toolbox.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -146,6 +146,7 @@ MMDetection3D 是一款由来自不同高校和企业的研发人员共同参与
 - [MMTracking](https://github.com/open-mmlab/mmtracking): OpenMMLab 一体化视频目标感知平台
 - [MMPose](https://github.com/open-mmlab/mmpose): OpenMMLab 姿态估计工具箱
 - [MMEditing](https://github.com/open-mmlab/mmediting): OpenMMLab 图像视频编辑工具箱
+- [MMOCR](https://github.com/open-mmlab/mmocr): OpenMMLab 全流程文字检测识别理解工具包
 - [MMGeneration](https://github.com/open-mmlab/mmgeneration): OpenMMLab 图片视频生成模型工具箱
 
 ## 欢迎加入 OpenMMLab 社区

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -146,7 +146,7 @@ MMDetection3D 是一款由来自不同高校和企业的研发人员共同参与
 - [MMTracking](https://github.com/open-mmlab/mmtracking): OpenMMLab 一体化视频目标感知平台
 - [MMPose](https://github.com/open-mmlab/mmpose): OpenMMLab 姿态估计工具箱
 - [MMEditing](https://github.com/open-mmlab/mmediting): OpenMMLab 图像视频编辑工具箱
-- [MMGeneration](https://github.com/open-mmlab/mmgeneration): OpenMMLab 生成模型工具箱
+- [MMGeneration](https://github.com/open-mmlab/mmgeneration): OpenMMLab 图片视频生成模型工具箱
 
 ## 欢迎加入 OpenMMLab 社区
 

--- a/docs/tutorials/customize_runtime.md
+++ b/docs/tutorials/customize_runtime.md
@@ -20,8 +20,8 @@ To modify the learning rate of the model, the users only need to modify the `lr`
 A customized optimizer could be defined as following.
 
 Assume you want to add a optimizer named `MyOptimizer`, which has arguments `a`, `b`, and `c`.
-You need to create a new directory named `mmdet/core/optimizer`.
-And then implement the new optimizer in a file, e.g., in `mmdet/core/optimizer/my_optimizer.py`:
+You need to create a new directory named `mmdet3d/core/optimizer`.
+And then implement the new optimizer in a file, e.g., in `mmdet3d/core/optimizer/my_optimizer.py`:
 
 ```python
 from mmcv.runner.optimizer import OPTIMIZERS
@@ -39,9 +39,9 @@ class MyOptimizer(Optimizer):
 
 To find the above module defined above, this module should be imported into the main namespace at first. There are two options to achieve it.
 
-- Modify `mmdet/core/optimizer/__init__.py` to import it.
+- Modify `mmdet3d/core/optimizer/__init__.py` to import it.
 
-    The newly defined module should be imported in `mmdet/core/optimizer/__init__.py` so that the registry will
+    The newly defined module should be imported in `mmdet3d/core/optimizer/__init__.py` so that the registry will
     find the new module and add it:
 
 ```python
@@ -51,21 +51,21 @@ __all__ = ['MyOptimizer']
 
 ```
 
-You also need to import `optimizer` in `mmdet/core/__init__.py` by adding:
+You also need to import `optimizer` in `mmdet3d/core/__init__.py` by adding:
 
 ```python
 from .optimizer import *  # noqa: F401, F403
 ```
 
-- Use `custom_imports` in the config to manually import it
+- Add `custom_imports` in the config to manually import it
 
 ```python
-custom_imports = dict(imports=['mmdet.core.optimizer.my_optimizer'], allow_failed_imports=False)
+custom_imports = dict(imports=['mmdet3d.core.optimizer.my_optimizer'], allow_failed_imports=False)
 ```
 
-The module `mmdet.core.optimizer.my_optimizer` will be imported at the beginning of the program and the class `MyOptimizer` is then automatically registered.
+The module `mmdet3d.core.optimizer.my_optimizer` will be imported at the beginning of the program and the class `MyOptimizer` is then automatically registered.
 Note that only the package containing the class `MyOptimizer` should be imported.
-`mmdet.core.optimizer.my_optimizer.MyOptimizer` **cannot** be imported directly.
+`mmdet3d.core.optimizer.my_optimizer.MyOptimizer` **cannot** be imported directly.
 
 Actually users can use a totally different file directory structure using this importing method, as long as the module root can be located in `PYTHONPATH`.
 
@@ -199,7 +199,7 @@ so that 1 epoch for training and 1 epoch for validation will be run iteratively.
 
 There are some occasions when the users might need to implement a new hook. MMDetection supports customized hooks in training (#3395) since v2.3.0. Thus the users could implement a hook directly in mmdet or their mmdet-based codebases and use the hook by only modifying the config in training.
 Before v2.3.0, the users need to modify the code to get the hook registered before training starts.
-Here we give an example of creating a new hook in mmdet and using it in training.
+Here we give an example of creating a new hook in mmdet3d and using it in training.
 
 ```python
 from mmcv.runner import HOOKS, Hook
@@ -234,21 +234,24 @@ Depending on the functionality of the hook, the users need to specify what the h
 
 #### 2. Register the new hook
 
-Then we need to make `MyHook` imported. Assuming the file is in `mmdet/core/utils/my_hook.py` there are two ways to do that:
+Then we need to make `MyHook` imported. Assuming the file is in `mmdet3d/core/utils/my_hook.py` there are two ways to do that:
 
-- Modify `mmdet/core/utils/__init__.py` to import it.
+- Modify `mmdet3d/core/utils/__init__.py` to import it.
 
-    The newly defined module should be imported in `mmdet/core/utils/__init__.py` so that the registry will
+    The newly defined module should be imported in `mmdet3d/core/utils/__init__.py` so that the registry will
     find the new module and add it:
 
 ```python
 from .my_hook import MyHook
+
+__all__ = [..., 'MyHook']
+
 ```
 
 - Use `custom_imports` in the config to manually import it
 
 ```python
-custom_imports = dict(imports=['mmdet.core.utils.my_hook'], allow_failed_imports=False)
+custom_imports = dict(imports=['mmdet3d.core.utils.my_hook'], allow_failed_imports=False)
 ```
 
 #### 3. Modify the config

--- a/docs/tutorials/customize_runtime.md
+++ b/docs/tutorials/customize_runtime.md
@@ -39,7 +39,7 @@ class MyOptimizer(Optimizer):
 
 To find the above module defined above, this module should be imported into the main namespace at first. There are two options to achieve it.
 
-- Modify `mmdet3d/core/optimizer/__init__.py` to import it.
+- Add `mmdet3d/core/optimizer/__init__.py` to import it.
 
     The newly defined module should be imported in `mmdet3d/core/optimizer/__init__.py` so that the registry will
     find the new module and add it:
@@ -57,7 +57,7 @@ You also need to import `optimizer` in `mmdet3d/core/__init__.py` by adding:
 from .optimizer import *  # noqa: F401, F403
 ```
 
-- Add `custom_imports` in the config to manually import it
+- Use `custom_imports` in the config to manually import it
 
 ```python
 custom_imports = dict(imports=['mmdet3d.core.optimizer.my_optimizer'], allow_failed_imports=False)

--- a/docs/tutorials/customize_runtime.md
+++ b/docs/tutorials/customize_runtime.md
@@ -24,7 +24,7 @@ You need to create a new directory named `mmdet/core/optimizer`.
 And then implement the new optimizer in a file, e.g., in `mmdet/core/optimizer/my_optimizer.py`:
 
 ```python
-from .registry import OPTIMIZERS
+from mmcv.runner.optimizer import OPTIMIZERS
 from torch.optim import Optimizer
 
 
@@ -46,6 +46,15 @@ To find the above module defined above, this module should be imported into the 
 
 ```python
 from .my_optimizer import MyOptimizer
+
+__all__ = ['MyOptimizer']
+
+```
+
+You also need to import `optimizer` in `mmdet/core/__init__.py` by adding:
+
+```python
+from .optimizer import *  # noqa: F401, F403
 ```
 
 - Use `custom_imports` in the config to manually import it


### PR DESCRIPTION
The ignored data folder should be `data/xxx` instead of `/data/xxx`.
MMDet no longer has `mmdet/core/optimizer`. Instead, they use optimizer from `mmcv`. I modify this part of docs accordingly.