### PR TITLE
Fix: #473 changed default arg value for `show_result` and caused `--show` broke during testing

### DIFF
--- a/mmdet3d/core/visualizer/show_result.py
+++ b/mmdet3d/core/visualizer/show_result.py
@@ -75,7 +75,7 @@ def show_result(points,
                 pred_bboxes,
                 out_dir,
                 filename,
-                show=False,
+                show=True,
                 snapshot=False):
     """Convert results into format that is directly readable for meshlab.
 


### PR DESCRIPTION
In #473, it [changed the default arg value of `mmdet3d.core.visualizer.show_result`](https://github.com/open-mmlab/mmdetection3d/blob/master/mmdet3d/core/visualizer/show_result.py#L78), from `show=True` to `show=False`, which caused code `mmdet3d.models.detectors.{mvx_two_stage/base}.show_results` to broke (not showing the visualization even when `--show` is enabled during testing.