### PR TITLE
[Enhance] Add MMSeg requirement in docs & code

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,12 @@ RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build 
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install MMCV
+# Install MMCV, MMDetection and MMSegmentation
 RUN pip install mmcv-full==latest+torch1.6.0+cu101 -f https://openmmlab.oss-accelerate.aliyuncs.com/mmcv/dist/index.html
 RUN pip install mmdet==2.11.0
+RUN pip install mmseg
 
-# Install MMDetection
+# Install MMDetection3D
 RUN conda clean --all
 RUN git clone https://github.com/open-mmlab/mmdetection3d.git /mmdetection3d
 WORKDIR /mmdetection3d

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,20 +8,20 @@
 - [MMCV](https://mmcv.readthedocs.io/en/latest/#installation)
 
 
-The required versions of MMCV and MMDetection for different versions of MMDetection3D are as below. Please install the correct version of MMCV and MMDetection to avoid installation issues.
+The required versions of MMCV, MMDetection and MMSegmentation for different versions of MMDetection3D are as below. Please install the correct version of MMCV, MMDetection and MMSegmentation to avoid installation issues.
 
-| MMDetection3D version | MMDetection version |    MMCV version     |
-|:-------------------:|:-------------------:|:-------------------:|
-| master              | mmdet>=2.10.0, <=2.11.0| mmcv-full>=1.2.4, <=1.4|
-| 0.13.0              | mmdet>=2.10.0, <=2.11.0| mmcv-full>=1.2.4, <=1.4|
-| 0.12.0              | mmdet>=2.5.0, <=2.11.0 | mmcv-full>=1.2.4, <=1.4|
-| 0.11.0              | mmdet>=2.5.0, <=2.11.0 | mmcv-full>=1.2.4, <=1.4|
-| 0.10.0              | mmdet>=2.5.0, <=2.11.0 | mmcv-full>=1.2.4, <=1.4|
-| 0.9.0               | mmdet>=2.5.0, <=2.11.0 | mmcv-full>=1.2.4, <=1.4|
-| 0.8.0               | mmdet>=2.5.0, <=2.11.0 | mmcv-full>=1.1.5, <=1.4|
-| 0.7.0               | mmdet>=2.5.0, <=2.11.0 | mmcv-full>=1.1.5, <=1.4|
-| 0.6.0               | mmdet>=2.4.0, <=2.11.0 | mmcv-full>=1.1.3, <=1.2|
-| 0.5.0               | 2.3.0                  | mmcv-full==1.0.5|
+| MMDetection3D version | MMDetection version | MMSegmentation version |    MMCV version     |
+|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
+| master              | mmdet>=2.10.0, <=2.11.0| mmseg>=0.13.0 | mmcv-full>=1.2.4, <=1.4|
+| 0.13.0              | mmdet>=2.10.0, <=2.11.0| Not required  | mmcv-full>=1.2.4, <=1.4|
+| 0.12.0              | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.2.4, <=1.4|
+| 0.11.0              | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.2.4, <=1.4|
+| 0.10.0              | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.2.4, <=1.4|
+| 0.9.0               | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.2.4, <=1.4|
+| 0.8.0               | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.1.5, <=1.4|
+| 0.7.0               | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.1.5, <=1.4|
+| 0.6.0               | mmdet>=2.4.0, <=2.11.0 | Not required  | mmcv-full>=1.1.3, <=1.2|
+| 0.5.0               | 2.3.0                  | Not required  | mmcv-full==1.0.5|
 
 # Installation
 
@@ -110,14 +110,28 @@ pip install -r requirements/build.txt
 pip install -v -e .  # or "python setup.py develop"
 ```
 
-**e. Clone the MMDetection3D repository.**
+**e. Install [MMSegmentation](https://github.com/open-mmlab/mmsegmentation).**
+
+```shell
+pip install git+https://github.com/open-mmlab/mmsegmentation.git
+```
+
+Optionally, you could also build MMSegmentation from source in case you want to modify the code:
+
+```shell
+git clone https://github.com/open-mmlab/mmsegmentation.git
+cd mmsegmentation
+pip install -e .  # or "python setup.py develop"
+```
+
+**f. Clone the MMDetection3D repository.**
 
 ```shell
 git clone https://github.com/open-mmlab/mmdetection3d.git
 cd mmdetection3d
 ```
 
-**f.Install build requirements and then install MMDetection3D.**
+**g.Install build requirements and then install MMDetection3D.**
 
 ```shell
 pip install -v -e .  # or "python setup.py develop"
@@ -176,6 +190,9 @@ pip install mmcv-full
 
 # install mmdetection
 pip install git+https://github.com/open-mmlab/mmdetection.git
+
+# install mmsegmentation
+pip install git+https://github.com/open-mmlab/mmsegmentation.git
 
 # install mmdetection3d
 git clone https://github.com/open-mmlab/mmdetection3d.git

--- a/mmdet3d/__init__.py
+++ b/mmdet3d/__init__.py
@@ -39,7 +39,7 @@ assert (mmdet_version >= digit_version(mmdet_minimum_version)
 # TODO: actually we are incompatibile with even the newest mmseg
 # TODO: some changes are still in master branch and not released yet
 mmseg_minimum_version = '0.13.0'
-mmseg_maximum_version = '1.0.0'
+mmseg_maximum_version = '0.13.0'
 mmseg_version = digit_version(mmseg.__version__)
 assert (mmseg_version >= digit_version(mmseg_minimum_version)
         and mmseg_version <= digit_version(mmseg_maximum_version)), \

--- a/mmdet3d/__init__.py
+++ b/mmdet3d/__init__.py
@@ -1,6 +1,7 @@
 import mmcv
 
 import mmdet
+import mmseg
 from .version import __version__, short_version
 
 
@@ -34,5 +35,16 @@ assert (mmdet_version >= digit_version(mmdet_minimum_version)
     f'MMDET=={mmdet.__version__} is used but incompatible. ' \
     f'Please install mmdet>={mmdet_minimum_version}, ' \
     f'<={mmdet_maximum_version}.'
+
+# TODO: actually we are incompatibile with even the newest mmseg
+# TODO: some changes are still in master branch and not released yet
+mmseg_minimum_version = '0.13.0'
+mmseg_maximum_version = '1.0.0'
+mmseg_version = digit_version(mmseg.__version__)
+assert (mmseg_version >= digit_version(mmseg_minimum_version)
+        and mmseg_version <= digit_version(mmseg_maximum_version)), \
+    f'MMSEG=={mmseg.__version__} is used but incompatible. ' \
+    f'Please install mmseg>={mmseg_minimum_version}, ' \
+    f'<={mmseg_maximum_version}.'
 
 __all__ = ['__version__', 'short_version']

--- a/mmdet3d/utils/collect_env.py
+++ b/mmdet3d/utils/collect_env.py
@@ -3,12 +3,14 @@ from mmcv.utils import get_git_hash
 
 import mmdet
 import mmdet3d
+import mmseg
 
 
 def collect_env():
     """Collect the information of the running environments."""
     env_info = collect_base_env()
     env_info['MMDetection'] = mmdet.__version__
+    env_info['MMSegmentation'] = mmseg.__version__
     env_info['MMDetection3D'] = mmdet3d.__version__ + '+' + get_git_hash()[:7]
 
     return env_info


### PR DESCRIPTION
From mmdet3d 0.14.0, we will have MMSegmentation as our requirement. I add the version check in code and instructions about its installation in the docs.

Actually, the master branch of mmdet3d now is incompatible with MMSeg. Their newest version (0.13.0) has finished MMCV MODEL registry refactor while we haven't. Their earlier version will cause errors in training 3D segmentors. The best solution is to have our PR #378 merged as soon as possible.