### PR TITLE
[Fix] Converting point with specified rt_matrix

### DIFF
--- a/mmdet3d/core/bbox/structures/coord_3d_mode.py
+++ b/mmdet3d/core/bbox/structures/coord_3d_mode.py
@@ -220,9 +220,11 @@ class Coord3DMode(IntEnum):
         # convert point from `src` mode to `dst` mode.
         # TODO: LIDAR
         # only implemented provided Rt matrix in cam-depth conversion
-        if src == Coord3DMode.LIDAR and dst == Coord3DMode.CAM:
+        if (src == Coord3DMode.LIDAR
+                and dst == Coord3DMode.CAM) and rt_mat is None:
             rt_mat = arr.new_tensor([[0, -1, 0], [0, 0, -1], [1, 0, 0]])
-        elif src == Coord3DMode.CAM and dst == Coord3DMode.LIDAR:
+        elif (src == Coord3DMode.CAM
+              and dst == Coord3DMode.LIDAR) and rt_mat is None:
             rt_mat = arr.new_tensor([[0, 0, 1], [-1, 0, 0], [0, -1, 0]])
         elif src == Coord3DMode.DEPTH and dst == Coord3DMode.CAM:
             if rt_mat is None:
@@ -237,9 +239,11 @@ class Coord3DMode(IntEnum):
             else:
                 rt_mat = rt_mat @ rt_mat.new_tensor([[1, 0, 0], [0, 0, 1],
                                                      [0, -1, 0]])
-        elif src == Coord3DMode.LIDAR and dst == Coord3DMode.DEPTH:
+        elif (src == Coord3DMode.LIDAR
+              and dst == Coord3DMode.DEPTH) and rt_mat is None:
             rt_mat = arr.new_tensor([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
-        elif src == Coord3DMode.DEPTH and dst == Coord3DMode.LIDAR:
+        elif (src == Coord3DMode.DEPTH
+              and dst == Coord3DMode.LIDAR) and rt_mat is None:
             rt_mat = arr.new_tensor([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
         else:
             raise NotImplementedError(

--- a/mmdet3d/core/bbox/structures/coord_3d_mode.py
+++ b/mmdet3d/core/bbox/structures/coord_3d_mode.py
@@ -245,7 +245,7 @@ class Coord3DMode(IntEnum):
         elif (src == Coord3DMode.DEPTH
               and dst == Coord3DMode.LIDAR) and rt_mat is None:
             rt_mat = arr.new_tensor([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
-        else:
+        elif rt_mat is None:
             raise NotImplementedError(
                 f'Conversion from Coord3DMode {src} to {dst} '
                 'is not supported yet')

--- a/mmdet3d/core/bbox/structures/coord_3d_mode.py
+++ b/mmdet3d/core/bbox/structures/coord_3d_mode.py
@@ -220,13 +220,16 @@ class Coord3DMode(IntEnum):
         # convert point from `src` mode to `dst` mode.
         # TODO: LIDAR
         # only implemented provided Rt matrix in cam-depth conversion
-        if (src == Coord3DMode.LIDAR
-                and dst == Coord3DMode.CAM) and rt_mat is None:
-            rt_mat = arr.new_tensor([[0, -1, 0], [0, 0, -1], [1, 0, 0]])
-        elif (src == Coord3DMode.CAM
-              and dst == Coord3DMode.LIDAR) and rt_mat is None:
-            rt_mat = arr.new_tensor([[0, 0, 1], [-1, 0, 0], [0, -1, 0]])
+        if src == Coord3DMode.LIDAR and dst == Coord3DMode.CAM:
+            if rt_mat is None:
+                rt_mat = arr.new_tensor([[0, -1, 0], [0, 0, -1], [1, 0, 0]])
+        elif src == Coord3DMode.CAM and dst == Coord3DMode.LIDAR:
+            if rt_mat is None:
+                rt_mat = arr.new_tensor([[0, 0, 1], [-1, 0, 0], [0, -1, 0]])
         elif src == Coord3DMode.DEPTH and dst == Coord3DMode.CAM:
+            # LIDAR-CAM conversion is different from DEPTH-CAM conversion
+            # because SUNRGB-D camera calibration files are different from
+            # that of KITTI, and currently we keep this hack
             if rt_mat is None:
                 rt_mat = arr.new_tensor([[1, 0, 0], [0, 0, -1], [0, 1, 0]])
             else:
@@ -239,13 +242,13 @@ class Coord3DMode(IntEnum):
             else:
                 rt_mat = rt_mat @ rt_mat.new_tensor([[1, 0, 0], [0, 0, 1],
                                                      [0, -1, 0]])
-        elif (src == Coord3DMode.LIDAR
-              and dst == Coord3DMode.DEPTH) and rt_mat is None:
-            rt_mat = arr.new_tensor([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
-        elif (src == Coord3DMode.DEPTH
-              and dst == Coord3DMode.LIDAR) and rt_mat is None:
-            rt_mat = arr.new_tensor([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
-        elif rt_mat is None:
+        elif src == Coord3DMode.LIDAR and dst == Coord3DMode.DEPTH:
+            if rt_mat is None:
+                rt_mat = arr.new_tensor([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+        elif src == Coord3DMode.DEPTH and dst == Coord3DMode.LIDAR:
+            if rt_mat is None:
+                rt_mat = arr.new_tensor([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])
+        else:
             raise NotImplementedError(
                 f'Conversion from Coord3DMode {src} to {dst} '
                 'is not supported yet')


### PR DESCRIPTION
* Fixing the bug that the specified rt_matrix will be overwritten by fixed constant when converting from lidar to cam, or from cam to lidar, or from lidar to depth, or from depth to lidar.