### PR TITLE
[Enhance] Add missing unit tests for pipeline functions

### DIFF
--- a/mmdet3d/datasets/__init__.py
+++ b/mmdet3d/datasets/__init__.py
@@ -11,9 +11,9 @@ from .pipelines import (BackgroundPointsFilter, GlobalAlignment,
                         GlobalRotScaleTrans, IndoorPatchPointSample,
                         IndoorPointSample, LoadAnnotations3D,
                         LoadPointsFromFile, LoadPointsFromMultiSweeps,
-                        NormalizePointsColor, ObjectNoise, ObjectRangeFilter,
-                        ObjectSample, PointShuffle, PointsRangeFilter,
-                        RandomDropPointsColor, RandomFlip3D,
+                        NormalizePointsColor, ObjectNameFilter, ObjectNoise,
+                        ObjectRangeFilter, ObjectSample, PointShuffle,
+                        PointsRangeFilter, RandomDropPointsColor, RandomFlip3D,
                         RandomJitterPoints, VoxelBasedPointSampler)
 from .s3dis_dataset import S3DISSegDataset
 from .scannet_dataset import ScanNetDataset, ScanNetSegDataset
@@ -34,5 +34,5 @@ __all__ = [
     'ScanNetSegDataset', 'SemanticKITTIDataset', 'Custom3DDataset',
     'Custom3DSegDataset', 'LoadPointsFromMultiSweeps', 'WaymoDataset',
     'BackgroundPointsFilter', 'VoxelBasedPointSampler', 'get_loading_pipeline',
-    'RandomDropPointsColor', 'RandomJitterPoints'
+    'RandomDropPointsColor', 'RandomJitterPoints', 'ObjectNameFilter'
 ]

--- a/mmdet3d/datasets/pipelines/__init__.py
+++ b/mmdet3d/datasets/pipelines/__init__.py
@@ -8,10 +8,11 @@ from .loading import (LoadAnnotations3D, LoadImageFromFileMono3D,
 from .test_time_aug import MultiScaleFlipAug3D
 from .transforms_3d import (BackgroundPointsFilter, GlobalAlignment,
                             GlobalRotScaleTrans, IndoorPatchPointSample,
-                            IndoorPointSample, ObjectNoise, ObjectRangeFilter,
-                            ObjectSample, PointShuffle, PointsRangeFilter,
-                            RandomDropPointsColor, RandomFlip3D,
-                            RandomJitterPoints, VoxelBasedPointSampler)
+                            IndoorPointSample, ObjectNameFilter, ObjectNoise,
+                            ObjectRangeFilter, ObjectSample, PointShuffle,
+                            PointsRangeFilter, RandomDropPointsColor,
+                            RandomFlip3D, RandomJitterPoints,
+                            VoxelBasedPointSampler)
 
 __all__ = [
     'ObjectSample', 'RandomFlip3D', 'ObjectNoise', 'GlobalRotScaleTrans',
@@ -21,6 +22,6 @@ __all__ = [
     'NormalizePointsColor', 'LoadAnnotations3D', 'IndoorPointSample',
     'PointSegClassMapping', 'MultiScaleFlipAug3D', 'LoadPointsFromMultiSweeps',
     'BackgroundPointsFilter', 'VoxelBasedPointSampler', 'GlobalAlignment',
-    'IndoorPatchPointSample', 'LoadImageFromFileMono3D',
+    'IndoorPatchPointSample', 'LoadImageFromFileMono3D', 'ObjectNameFilter',
     'RandomDropPointsColor', 'RandomJitterPoints'
 ]

--- a/mmdet3d/datasets/pipelines/transforms_3d.py
+++ b/mmdet3d/datasets/pipelines/transforms_3d.py
@@ -532,6 +532,8 @@ class GlobalRotScaleTrans(object):
             translation_std = [
                 translation_std, translation_std, translation_std
             ]
+        assert all([std >= 0 for std in translation_std]), \
+            'translation_std should be positive'
         self.translation_std = translation_std
         self.shift_height = shift_height
 

--- a/tests/test_data/test_pipelines/test_augmentations/test_transforms_3d.py
+++ b/tests/test_data/test_pipelines/test_augmentations/test_transforms_3d.py
@@ -270,9 +270,11 @@ def test_global_rot_scale_trans():
     with pytest.raises(AssertionError):
         global_rot_scale_trans = GlobalRotScaleTrans(scale_ratio_range=1.0)
 
-    # translation_std should be a number or seq of numbers
+    # translation_std should be a positive number or seq of positive numbers
     with pytest.raises(AssertionError):
         global_rot_scale_trans = GlobalRotScaleTrans(translation_std='0.0')
+    with pytest.raises(AssertionError):
+        global_rot_scale_trans = GlobalRotScaleTrans(translation_std=-1.0)
 
     global_rot_scale_trans = GlobalRotScaleTrans(
         rot_range=angle,

--- a/tests/test_data/test_pipelines/test_loadings/test_loading.py
+++ b/tests/test_data/test_pipelines/test_loadings/test_loading.py
@@ -5,10 +5,15 @@ from os import path as osp
 
 from mmdet3d.core.bbox import DepthInstance3DBoxes
 from mmdet3d.core.points import DepthPoints, LiDARPoints
-from mmdet3d.datasets.pipelines import (LoadAnnotations3D, LoadPointsFromFile,
+# yapf: disable
+from mmdet3d.datasets.pipelines import (LoadAnnotations3D,
+                                        LoadImageFromFileMono3D,
+                                        LoadPointsFromFile,
                                         LoadPointsFromMultiSweeps,
                                         NormalizePointsColor,
                                         PointSegClassMapping)
+
+# yapf: enable
 
 
 def test_load_points_from_indoor_file():
@@ -286,6 +291,25 @@ def test_load_points_from_multi_sweeps():
     expected_repr_str = 'LoadPointsFromMultiSweeps(sweeps_num=10)'
     assert repr_str == expected_repr_str
     assert points.shape == (403, 4)
+
+
+def test_load_image_from_file_mono_3d():
+    load_image_from_file_mono_3d = LoadImageFromFileMono3D()
+    filename = 'tests/data/nuscenes/samples/CAM_BACK_LEFT/' \
+        'n015-2018-07-18-11-07-57+0800__CAM_BACK_LEFT__1531883530447423.jpg'
+    cam_intrinsic = np.array([[1256.74, 0.0, 792.11], [0.0, 1256.74, 492.78],
+                              [0.0, 0.0, 1.0]])
+    input_dict = dict(
+        img_prefix=None,
+        img_info=dict(filename=filename, cam_intrinsic=cam_intrinsic.copy()))
+    results = load_image_from_file_mono_3d(input_dict)
+    assert results['img'].shape == (900, 1600, 3)
+    assert np.all(results['cam_intrinsic'] == cam_intrinsic)
+
+    repr_str = repr(load_image_from_file_mono_3d)
+    expected_repr_str = 'LoadImageFromFileMono3D(to_float32=False, ' \
+        "color_type='color', file_client_args={'backend': 'disk'})"
+    assert repr_str == expected_repr_str
 
 
 def test_point_seg_class_mapping():


### PR DESCRIPTION
Now all functions under `mmdet3d/datasets/pipeline/` have their own unit tests.