### PR TITLE
[Fix] Fix mmseg max version requirement

### DIFF
--- a/mmdet3d/__init__.py
+++ b/mmdet3d/__init__.py
@@ -36,10 +36,8 @@ assert (mmdet_version >= digit_version(mmdet_minimum_version)
     f'Please install mmdet>={mmdet_minimum_version}, ' \
     f'<={mmdet_maximum_version}.'
 
-# TODO: actually we are incompatibile with even the newest mmseg
-# TODO: some changes are still in master branch and not released yet
 mmseg_minimum_version = '0.13.0'
-mmseg_maximum_version = '0.13.0'
+mmseg_maximum_version = '0.14.0'
 mmseg_version = digit_version(mmseg.__version__)
 assert (mmseg_version >= digit_version(mmseg_minimum_version)
         and mmseg_version <= digit_version(mmseg_maximum_version)), \


### PR DESCRIPTION
MMDet3D is compatibility with mmseg >= 0.13.0, including 0.14.0 which is their newest release.