### PR TITLE
[Fix] Fix potential bug in using `analyze_logs`

### DIFF
--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -53,14 +53,18 @@ def plot_curve(log_dicts, args):
                     f'{args.json_logs[i]} does not contain metric {metric}')
 
             if args.mode == 'eval':
-                xs = np.arange(args.interval, max(epochs) + 1, args.interval)
+                # if current training is resumed from previous checkpoint
+                # we lost information in early epochs
+                # `xs` should start according to `min(epochs)`
+                x0 = min(epochs) + args.interval - min(epochs) % args.interval
+                xs = np.arange(x0, max(epochs) + 1, args.interval)
                 ys = []
                 for epoch in epochs[args.interval - 1::args.interval]:
                     ys += log_dict[epoch][metric]
 
                 # if training is aborted before eval of the last epoch
-                # xs and ys will have different length and cause an error
-                # check if ys[-1] is empty here
+                # `xs` and `ys` will have different length and cause an error
+                # check if `ys[-1]` is empty here
                 if not log_dict[epoch][metric]:
                     xs = xs[:-1]
 

--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -57,6 +57,13 @@ def plot_curve(log_dicts, args):
                 ys = []
                 for epoch in epochs[args.interval - 1::args.interval]:
                     ys += log_dict[epoch][metric]
+
+                # if training is aborted before eval of the last epoch
+                # xs and ys will have different length and cause an error
+                # check if ys[-1] is empty here
+                if not log_dict[epoch][metric]:
+                    xs = xs[:-1]
+
                 ax = plt.gca()
                 ax.set_xticks(xs)
                 plt.xlabel('epoch')


### PR DESCRIPTION
## Motivation
There are two errors I have encountered when using `analyze_logs.py` to plot eval metrics:
1. When the log is generated in an experiment that **resume** from a checkpoint, we won't have info in previous epochs in the json file. Thus we need to adjust the start epoch in `xs`. Current code assume we start from epoch 1 which is not always the case.
2. When an experiment is killed or stopped before eval, we won't have metric value in the last epoch. However, current code assumes it exists so will cause a length error. We judge if eval is performed in the last epoch and drop the last epoch in `xs` if not.

## Modification
Described above.

## BC-breaking (Optional)
No

## Use cases (Optional)
No
