### PR TITLE
[Fix] Fix MMSeg max version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.torch_version}}/index.html
           pip install mmdet==2.11.0
-          pip install mmseg==0.14.0
+          pip install mmsegmentation==0.14.0
           pip install -r requirements.txt
       - name: Build and install
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.torch_version}}/index.html
           pip install mmdet==2.11.0
-          pip install -q git+https://github.com/open-mmlab/mmsegmentation.git
+          pip install mmseg==0.14.0
           pip install -r requirements.txt
       - name: Build and install
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build 
 # Install MMCV, MMDetection and MMSegmentation
 RUN pip install mmcv-full==latest+torch1.6.0+cu101 -f https://openmmlab.oss-accelerate.aliyuncs.com/mmcv/dist/index.html
 RUN pip install mmdet==2.11.0
-RUN pip install mmsegmentation==0.13.0
+RUN pip install mmsegmentation==0.14.0
 
 # Install MMDetection3D
 RUN conda clean --all

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -99,7 +99,7 @@ Note:
 MMDetection3D v0.14.0 is only compatible with MMDetection version `mmdet>=2.10.0, <=2.11.0`. The future versions will only support `mmdet>=2.12.0` since v0.15.0 (to be released in July).
 
 ```shell
-pip install git+https://github.com/open-mmlab/mmdetection.git
+pip install mmdet==2.11.0
 ```
 
 Optionally, you could also build MMDetection from source in case you want to modify the code:
@@ -107,6 +107,7 @@ Optionally, you could also build MMDetection from source in case you want to mod
 ```shell
 git clone https://github.com/open-mmlab/mmdetection.git
 cd mmdetection
+git checkout 2894516  # switch to v2.11.0 branch
 pip install -r requirements/build.txt
 pip install -v -e .  # or "python setup.py develop"
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,8 +12,8 @@ The required versions of MMCV, MMDetection and MMSegmentation for different vers
 
 | MMDetection3D version | MMDetection version | MMSegmentation version |    MMCV version     |
 |:-------------------:|:-------------------:|:-------------------:|:-------------------:|
-| master              | mmdet>=2.10.0, <=2.11.0| mmseg>=0.13.0, <=0.14.0 | mmcv-full>=1.3.1, <=1.4|
-| 0.14.0              | mmdet>=2.10.0, <=2.11.0| mmseg>=0.13.0 | mmcv-full>=1.3.1, <=1.4|
+| master              | mmdet>=2.10.0, <=2.11.0| mmseg==0.14.0 | mmcv-full>=1.3.1, <=1.4|
+| 0.14.0              | mmdet>=2.10.0, <=2.11.0| mmseg==0.14.0 | mmcv-full>=1.3.1, <=1.4|
 | 0.13.0              | mmdet>=2.10.0, <=2.11.0| Not required  | mmcv-full>=1.2.4, <=1.4|
 | 0.12.0              | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.2.4, <=1.4|
 | 0.11.0              | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.2.4, <=1.4|
@@ -107,7 +107,7 @@ Optionally, you could also build MMDetection from source in case you want to mod
 ```shell
 git clone https://github.com/open-mmlab/mmdetection.git
 cd mmdetection
-git checkout 2894516  # switch to v2.11.0 branch
+git checkout v2.11.0  # switch to v2.11.0 branch
 pip install -r requirements/build.txt
 pip install -v -e .  # or "python setup.py develop"
 ```
@@ -123,7 +123,7 @@ Optionally, you could also build MMSegmentation from source in case you want to 
 ```shell
 git clone https://github.com/open-mmlab/mmsegmentation.git
 cd mmsegmentation
-git checkout 5d46314  # switch to v0.14.0 branch
+git checkout v0.14.0  # switch to v0.14.0 branch
 pip install -e .  # or "python setup.py develop"
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,7 +12,7 @@ The required versions of MMCV, MMDetection and MMSegmentation for different vers
 
 | MMDetection3D version | MMDetection version | MMSegmentation version |    MMCV version     |
 |:-------------------:|:-------------------:|:-------------------:|:-------------------:|
-| master              | mmdet>=2.10.0, <=2.11.0| mmseg>=0.13.0 | mmcv-full>=1.3.1, <=1.4|
+| master              | mmdet>=2.10.0, <=2.11.0| mmseg>=0.13.0, <=0.14.0 | mmcv-full>=1.3.1, <=1.4|
 | 0.14.0              | mmdet>=2.10.0, <=2.11.0| mmseg>=0.13.0 | mmcv-full>=1.3.1, <=1.4|
 | 0.13.0              | mmdet>=2.10.0, <=2.11.0| Not required  | mmcv-full>=1.2.4, <=1.4|
 | 0.12.0              | mmdet>=2.5.0, <=2.11.0 | Not required  | mmcv-full>=1.2.4, <=1.4|
@@ -115,7 +115,7 @@ pip install -v -e .  # or "python setup.py develop"
 **e. Install [MMSegmentation](https://github.com/open-mmlab/mmsegmentation).**
 
 ```shell
-pip install git+https://github.com/open-mmlab/mmsegmentation.git
+pip install mmsegmentation==0.14.0
 ```
 
 Optionally, you could also build MMSegmentation from source in case you want to modify the code:
@@ -123,6 +123,7 @@ Optionally, you could also build MMSegmentation from source in case you want to 
 ```shell
 git clone https://github.com/open-mmlab/mmsegmentation.git
 cd mmsegmentation
+git checkout 5d46314  # switch to v0.14.0 branch
 pip install -e .  # or "python setup.py develop"
 ```
 

--- a/mmdet3d/__init__.py
+++ b/mmdet3d/__init__.py
@@ -36,7 +36,7 @@ assert (mmdet_version >= digit_version(mmdet_minimum_version)
     f'Please install mmdet>={mmdet_minimum_version}, ' \
     f'<={mmdet_maximum_version}.'
 
-mmseg_minimum_version = '0.13.0'
+mmseg_minimum_version = '0.14.0'
 mmseg_maximum_version = '0.14.0'
 mmseg_version = digit_version(mmseg.__version__)
 assert (mmseg_version >= digit_version(mmseg_minimum_version)

--- a/mmdet3d/__init__.py
+++ b/mmdet3d/__init__.py
@@ -37,7 +37,7 @@ assert (mmdet_version >= digit_version(mmdet_minimum_version)
     f'<={mmdet_maximum_version}.'
 
 mmseg_minimum_version = '0.13.0'
-mmseg_maximum_version = '0.14.0'
+mmseg_maximum_version = '1.0.0'
 mmseg_version = digit_version(mmseg.__version__)
 assert (mmseg_version >= digit_version(mmseg_minimum_version)
         and mmseg_version <= digit_version(mmseg_maximum_version)), \

--- a/mmdet3d/__init__.py
+++ b/mmdet3d/__init__.py
@@ -37,7 +37,7 @@ assert (mmdet_version >= digit_version(mmdet_minimum_version)
     f'<={mmdet_maximum_version}.'
 
 mmseg_minimum_version = '0.13.0'
-mmseg_maximum_version = '1.0.0'
+mmseg_maximum_version = '0.14.0'
 mmseg_version = digit_version(mmseg.__version__)
 assert (mmseg_version >= digit_version(mmseg_minimum_version)
         and mmseg_version <= digit_version(mmseg_maximum_version)), \


### PR DESCRIPTION
MMDet3D is currently compatible with mmseg>=0.13.0, remove the max version limit.

Modify installation instruction to install mmdet 2.11.0.

**Edit**: we need to fix mmseg to 0.14.0 because of [this](https://github.com/open-mmlab/mmsegmentation/commit/db44d16e023fd248280943c0bac79b9b5ce11042) commit.