### PR TITLE
[Enhance] Modified np.allclose to np.equal in background_points_filter unittest

### DIFF
--- a/tests/test_data/test_pipelines/test_augmentations/test_transforms_3d.py
+++ b/tests/test_data/test_pipelines/test_augmentations/test_transforms_3d.py
@@ -622,7 +622,7 @@ def test_background_points_filter():
                         '[[0.5, 2.0, 0.5]])'
     assert repr_str == expected_repr_str
     assert points.shape == (800, 4)
-    assert np.allclose(orig_points, points)
+    assert np.equal(orig_points, points)
 
     # test single float config
     BackgroundPointsFilter(0.5)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Using np.equal is better than np.allclose