### PR TITLE
[Enhance] Support RGB images on ScanNet for multi-view detector

### DIFF
--- a/data/scannet/README.md
+++ b/data/scannet/README.md
@@ -6,7 +6,9 @@ We follow the procedure in [votenet](https://github.com/facebookresearch/votenet
 
 2. In this directory, extract point clouds and annotations by running `python batch_load_scannet_data.py`. Add the `--max_num_point 50000` flag if you only use the ScanNet data for the detection task. It will downsample the scenes to less points.
 
-3. Enter the project root directory, generate training data by running
+3. In this directory, extract RGB image with poses by running `python extract_posed_images.py`. This step is optional. Skip it if you don't plan to use multi-view RGB images. Add `--max-images-per-scene -1` to disable limiting number of images per scene. ScanNet scenes contain up to 5000+ frames per each. And after extraction .jpg images requires around 2 Tb of dist space. The recommended 300 images per scene requires less then 100 Gb. For example multi-view 3d detector ImVoxelNet samples 50 and 100 images per training and test scene.
+
+4. Enter the project root directory, generate training data by running
 
 ```bash
 python tools/create_data.py scannet --root-path ./data/scannet --out-dir ./data/scannet --extra-tag scannet

--- a/tools/data_converter/scannet_data_utils.py
+++ b/tools/data_converter/scannet_data_utils.py
@@ -60,6 +60,10 @@ class ScanNetData(object):
         mmcv.check_file_exist(matrix_file)
         return np.load(matrix_file)
 
+    def get_images_and_poses(self, idx):
+        out_path = osp.join(self.root_dir, 'scans', idx, 'out')
+
+
     def get_infos(self, num_workers=4, has_label=True, sample_id_list=None):
         """Get data infos.
 


### PR DESCRIPTION
This PR aims to support RGB images on ScanNet for multi-view detector. More discussion in #620.

It is a bit WIP now as I also plan to add images to `ScanNetDataset`. For now I just adapted `SensReader` from original ScanNet [repo](https://github.com/ScanNet/ScanNet/tree/master/SensReader/python). Can you please check if we are ok with it? cc @Tai-Wang 