### PR TITLE
[Fix] Convert rt_mat to torch.Tensor in Coord transform for compatibility

### DIFF
--- a/mmdet3d/core/bbox/structures/coord_3d_mode.py
+++ b/mmdet3d/core/bbox/structures/coord_3d_mode.py
@@ -243,6 +243,9 @@ class Coord3DMode(IntEnum):
                 f'Conversion from Coord3DMode {src} to {dst} '
                 'is not supported yet')
 
+        if isinstance(rt_mat, np.ndarray):
+            rt_mat = arr.new_tensor(rt_mat)
+
         if rt_mat.size(1) == 4:
             extended_xyz = torch.cat(
                 [arr[:, :3], arr.new_ones(arr.size(0), 1)], dim=-1)

--- a/mmdet3d/core/bbox/structures/coord_3d_mode.py
+++ b/mmdet3d/core/bbox/structures/coord_3d_mode.py
@@ -243,9 +243,8 @@ class Coord3DMode(IntEnum):
                 f'Conversion from Coord3DMode {src} to {dst} '
                 'is not supported yet')
 
-        if isinstance(rt_mat, np.ndarray):
+        if not isinstance(rt_mat, torch.Tensor):
             rt_mat = arr.new_tensor(rt_mat)
-
         if rt_mat.size(1) == 4:
             extended_xyz = torch.cat(
                 [arr[:, :3], arr.new_ones(arr.size(0), 1)], dim=-1)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Convert `rt_mat` in 'coord_3d_mode.py' from np.ndarray to torch.Tensor. Closes #707 

## Modification
The `rt_mat` in 'coord_3d_mode.py' takes np.ndarray and torch.tensor types, but the conversion from np.ndarray to torch.Tensor is missing as further code assumes that `rt_mat` is a torch.Tensor type. So, conversion of `rt_mat` from np.ndarray to torch.tensor type is added! 

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
