### PR TITLE
[Fix] Move bev_range to ObjectRangeFilter's call for consistency with gt_bboxes_3d type

### DIFF
--- a/mmdet3d/datasets/pipelines/transforms_3d.py
+++ b/mmdet3d/datasets/pipelines/transforms_3d.py
@@ -4,8 +4,8 @@ from mmcv import is_tuple_of
 from mmcv.utils import build_from_cfg
 
 from mmdet3d.core import VoxelGenerator
-from mmdet3d.core.bbox import box_np_ops, LiDARInstance3DBoxes, \
-    CameraInstance3DBoxes, DepthInstance3DBoxes
+from mmdet3d.core.bbox import (CameraInstance3DBoxes, DepthInstance3DBoxes,
+                               LiDARInstance3DBoxes, box_np_ops)
 from mmdet.datasets.builder import PIPELINES
 from mmdet.datasets.pipelines import RandomFlip
 from ..builder import OBJECTSAMPLERS

--- a/mmdet3d/datasets/pipelines/transforms_3d.py
+++ b/mmdet3d/datasets/pipelines/transforms_3d.py
@@ -4,8 +4,8 @@ from mmcv import is_tuple_of
 from mmcv.utils import build_from_cfg
 
 from mmdet3d.core import VoxelGenerator
-from mmdet3d.core.bbox import box_np_ops
-from mmdet3d.core.points import LiDARPoints, CameraPoints, DepthPoints
+from mmdet3d.core.bbox import box_np_ops, LiDARInstance3DBoxes, \
+    CameraInstance3DBoxes, DepthInstance3DBoxes
 from mmdet.datasets.builder import PIPELINES
 from mmdet.datasets.pipelines import RandomFlip
 from ..builder import OBJECTSAMPLERS
@@ -712,9 +712,10 @@ class ObjectRangeFilter(object):
                 keys are updated in the result dict.
         """
         # Check points instance type and initialise bev_range
-        if isinstance(input_dict['points'], (LiDARPoints, DepthPoints)):
+        if isinstance(input_dict['gt_bboxes_3d'],
+                      (LiDARInstance3DBoxes, DepthInstance3DBoxes)):
             bev_range = self.pcd_range[[0, 1, 3, 4]]
-        elif isinstance(input_dict['points'], CameraPoints):
+        elif isinstance(input_dict['gt_bboxes_3d'], CameraInstance3DBoxes):
             bev_range = self.pcd_range[[0, 2, 3, 5]]
 
         gt_bboxes_3d = input_dict['gt_bboxes_3d']


### PR DESCRIPTION
## Motivation
Fix the `bev_range` initialization in ObjectRangeFilter according to the gt_bboxes_3d type. Closes #716 

## Modification
The `bev_range` initialization in ObjectRangeFilter `__init__` is moved to `__call__` to check the gt_bboxes_3d coordinate system type (like LiDAR or CAM) and initialize it accordingly.

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
No

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
