### PR TITLE
[Fix] Fix wrong in_channels when with_distance=True in VFE layers

### DIFF
--- a/mmdet3d/models/voxel_encoders/voxel_encoder.py
+++ b/mmdet3d/models/voxel_encoders/voxel_encoder.py
@@ -133,7 +133,7 @@ class DynamicVFE(nn.Module):
         if with_voxel_center:
             in_channels += 3
         if with_distance:
-            in_channels += 3
+            in_channels += 1
         self.in_channels = in_channels
         self._with_distance = with_distance
         self._with_cluster_center = with_cluster_center
@@ -331,7 +331,7 @@ class HardVFE(nn.Module):
         if with_voxel_center:
             in_channels += 3
         if with_distance:
-            in_channels += 3
+            in_channels += 1
         self.in_channels = in_channels
         self._with_distance = with_distance
         self._with_cluster_center = with_cluster_center


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Fix #675 

## Modification
Change to `in_channels += 1` when `with_distance=True`

## BC-breaking (Optional)
Current MMDet3D never uses VFE layers with `with_distance=True`, so this PR won't affect our codebase.

## Use cases (Optional)
N.A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
