### PR TITLE
[Fix] Fix bug in `BackgroundPointsFilter`

### DIFF
--- a/configs/3dssd/3dssd_4x4_kitti-3d-car.py
+++ b/configs/3dssd/3dssd_4x4_kitti-3d-car.py
@@ -50,7 +50,8 @@ train_pipeline = [
         type='GlobalRotScaleTrans',
         rot_range=[-0.78539816, 0.78539816],
         scale_ratio_range=[0.9, 1.1]),
-    dict(type='BackgroundPointsFilter', bbox_enlarge_range=(0.5, 2.0, 0.5)),
+    # 3DSSD can get a higher performance without this transform
+    # dict(type='BackgroundPointsFilter', bbox_enlarge_range=(0.5, 2.0, 0.5)),
     dict(type='IndoorPointSample', num_points=16384),
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points', 'gt_bboxes_3d', 'gt_labels_3d'])

--- a/mmdet3d/datasets/pipelines/transforms_3d.py
+++ b/mmdet3d/datasets/pipelines/transforms_3d.py
@@ -1174,10 +1174,10 @@ class BackgroundPointsFilter(object):
         enlarged_gt_bboxes_3d = gt_bboxes_3d_np.copy()
         enlarged_gt_bboxes_3d[:, 3:6] += self.bbox_enlarge_range
         points_numpy = points.tensor.clone().numpy()
-        foreground_masks = box_np_ops.points_in_rbbox(points_numpy,
-                                                      gt_bboxes_3d_np)
+        foreground_masks = box_np_ops.points_in_rbbox(
+            points_numpy, gt_bboxes_3d_np, origin=(0.5, 0.5, 0.5))
         enlarge_foreground_masks = box_np_ops.points_in_rbbox(
-            points_numpy, enlarged_gt_bboxes_3d)
+            points_numpy, enlarged_gt_bboxes_3d, origin=(0.5, 0.5, 0.5))
         foreground_masks = foreground_masks.max(1)
         enlarge_foreground_masks = enlarge_foreground_masks.max(1)
         valid_masks = ~np.logical_and(~foreground_masks,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
The first three coord of `gt_bboxes_3d_np` has been set to the gravity center [here](https://github.com/open-mmlab/mmdetection3d/blob/78f456216f101b5b684db754176e0def17ab9d49/mmdet3d/datasets/pipelines/transforms_3d.py#L1172). Then, we input the box and points to function `points_in_rbbox`. However, `points_in_rbbox` has a default params `origin=(0.5, 0.5, 0)` as shown [here](https://github.com/open-mmlab/mmdetection3d/blob/78f456216f101b5b684db754176e0def17ab9d49/mmdet3d/core/bbox/box_np_ops.py#L425), while the origin should be `(0.5, 0.5, 0.5)` instead. This cause a bug in calculating boxes and filtering surrounding points.

## Modification
Add `origin=(0.5, 0.5, 0.5)` input to the function `points_in_rbbox`.

## BC-breaking (Optional)
Currently, only 3DSSD uses `BackgroundPointsFilter` in MMDet3D codebase.

## Use cases (Optional)
N.A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
