### PR TITLE
[Fix] Add `max_keep_ckpts` for groupfree3d

### DIFF
--- a/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-L12-O256.py
+++ b/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-L12-O256.py
@@ -196,6 +196,7 @@ lr_config = dict(policy='step', warmup=None, step=[280, 340])
 
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=400)
+checkpoint_config = dict(interval=1, max_keep_ckpts=10)
 # yapf:disable
 log_config = dict(
     interval=30,

--- a/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-L6-O256.py
+++ b/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-L6-O256.py
@@ -195,6 +195,7 @@ lr_config = dict(policy='step', warmup=None, step=[280, 340])
 
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=400)
+checkpoint_config = dict(interval=1, max_keep_ckpts=10)
 # yapf:disable
 log_config = dict(
     interval=30,

--- a/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-w2x-L12-O256.py
+++ b/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-w2x-L12-O256.py
@@ -211,6 +211,7 @@ lr_config = dict(policy='step', warmup=None, step=[280, 340])
 
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=400)
+checkpoint_config = dict(interval=1, max_keep_ckpts=10)
 # yapf:disable
 log_config = dict(
     interval=30,

--- a/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-w2x-L12-O512.py
+++ b/configs/groupfree3d/groupfree3d_8x4_scannet-3d-18class-w2x-L12-O512.py
@@ -212,6 +212,7 @@ lr_config = dict(policy='step', warmup=None, step=[280, 340])
 
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=400)
+checkpoint_config = dict(interval=1, max_keep_ckpts=10)
 # yapf:disable
 log_config = dict(
     interval=30,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
The size of a most simple groupfree3d ckpt is around 170MB, and there are by default 400 ckpts saved in one run, which will take about 70GB space. There is a high chance of disk space/quota exceed, which will terminate training.

## Modification
I added  `max_keep_ckpts`  in groupfree3d configs.

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
