### PR TITLE
[Fix] Fix wrong GF3D cfg file name in unit test

### DIFF
--- a/mmdet3d/models/dense_heads/groupfree3d_head.py
+++ b/mmdet3d/models/dense_heads/groupfree3d_head.py
@@ -885,7 +885,7 @@ class GroupFree3DHead(BaseModule):
 
         prefixes = list()
         if self.test_cfg['prediction_stages'] == 'last':
-            prefixes = [f'_{self.num_decoder_layers - 1}']
+            prefixes = [f's{self.num_decoder_layers - 1}.']
         elif self.test_cfg['prediction_stages'] == 'all':
             prefixes = ['proposal.'] + \
                 [f's{i}.' for i in range(self.num_decoder_layers)]

--- a/tests/test_models/test_detectors.py
+++ b/tests/test_models/test_detectors.py
@@ -385,7 +385,7 @@ def test_groupfree3dnet():
 
     _setup_seed(0)
     groupfree3d_cfg = _get_detector_cfg(
-        'groupfree3d/groupfree3d_8x8_scannet-3d-18class-L6-O256.py')
+        'groupfree3d/groupfree3d_8x4_scannet-3d-18class-L6-O256.py')
     self = build_detector(groupfree3d_cfg).cuda()
 
     points_0 = torch.rand([50000, 3], device='cuda')

--- a/tests/test_models/test_heads/test_heads.py
+++ b/tests/test_models/test_heads/test_heads.py
@@ -1121,7 +1121,7 @@ def test_groupfree3d_head():
         pytest.skip('test requires GPU and torch+cuda')
     _setup_seed(0)
     vote_head_cfg = _get_vote_head_cfg(
-        'groupfree3d/groupfree3d_8x8_scannet-3d-18class-L6-O256.py')
+        'groupfree3d/groupfree3d_8x4_scannet-3d-18class-L6-O256.py')
     self = build_head(vote_head_cfg).cuda()
 
     fp_xyz = [torch.rand([2, 256, 3], dtype=torch.float32).cuda()]

--- a/tests/test_models/test_heads/test_heads.py
+++ b/tests/test_models/test_heads/test_heads.py
@@ -1134,13 +1134,13 @@ def test_groupfree3d_head():
     # test forward
     ret_dict = self(input_dict, 'kps')
     assert ret_dict['seeds_obj_cls_logits'].shape == torch.Size([2, 1, 256])
-    assert ret_dict['s5.center'].shape == torch.Size([2, 128, 3])
-    assert ret_dict['s5.dir_class'].shape == torch.Size([2, 128, 1])
-    assert ret_dict['s5.dir_res'].shape == torch.Size([2, 128, 1])
-    assert ret_dict['s5.size_class'].shape == torch.Size([2, 128, 18])
-    assert ret_dict['s5.size_res'].shape == torch.Size([2, 128, 18, 3])
-    assert ret_dict['s5.obj_scores'].shape == torch.Size([2, 128, 1])
-    assert ret_dict['s5.sem_scores'].shape == torch.Size([2, 128, 18])
+    assert ret_dict['s5.center'].shape == torch.Size([2, 256, 3])
+    assert ret_dict['s5.dir_class'].shape == torch.Size([2, 256, 1])
+    assert ret_dict['s5.dir_res'].shape == torch.Size([2, 256, 1])
+    assert ret_dict['s5.size_class'].shape == torch.Size([2, 256, 18])
+    assert ret_dict['s5.size_res'].shape == torch.Size([2, 256, 18, 3])
+    assert ret_dict['s5.obj_scores'].shape == torch.Size([2, 256, 1])
+    assert ret_dict['s5.sem_scores'].shape == torch.Size([2, 256, 18])
 
     # test losses
     points = [torch.rand([50000, 4], device='cuda') for i in range(2)]
@@ -1215,7 +1215,7 @@ def test_groupfree3d_head():
     bbox_preds['s5.size_res'] = size_res
     bbox_preds['s5.sem_scores'] = sem_scores
 
-    self.test_cfg['prediction_stages'] == 'last'
+    self.test_cfg['prediction_stages'] = 'last'
     results = self.get_bboxes(points, bbox_preds, [input_meta])
     assert results[0][0].tensor.shape[0] >= 0
     assert results[0][0].tensor.shape[1] == 7


### PR DESCRIPTION
GroupFree-3D's config files are `8x4`, while in the unit test they are `8x8`. Fix them in this PR