### PR TITLE
[Add] CenterPoint compatibility with KITTI

### DIFF
--- a/configs/_base_/models/centerpoint_01voxel_second_secfpn_kitti.py
+++ b/configs/_base_/models/centerpoint_01voxel_second_secfpn_kitti.py
@@ -1,0 +1,78 @@
+voxel_size = [0.05, 0.05, 0.1]
+model = dict(
+    type='CenterPoint',
+    pts_voxel_layer=dict(
+        max_num_points=5, voxel_size=voxel_size, max_voxels=(16000, 40000)),
+    pts_voxel_encoder=dict(type='HardSimpleVFE', num_features=4),
+    pts_middle_encoder=dict(
+        type='SparseEncoder',
+        in_channels=4,
+        sparse_shape=[41, 1600, 1408],
+        output_channels=128,
+        order=('conv', 'norm', 'act'),
+        encoder_channels=((16, 16, 32), (32, 32, 64), (64, 64, 128), (128,
+                                                                      128)),
+        encoder_paddings=((0, 0, 1), (0, 0, 1), (0, 0, [0, 1, 1]), (0, 0)),
+        block_type='basicblock'),
+    pts_backbone=dict(
+        type='SECOND',
+        in_channels=256,
+        out_channels=[128, 256],
+        layer_nums=[5, 5],
+        layer_strides=[1, 2],
+        norm_cfg=dict(type='BN', eps=1e-3, momentum=0.01),
+        conv_cfg=dict(type='Conv2d', bias=False)),
+    pts_neck=dict(
+        type='SECONDFPN',
+        in_channels=[128, 256],
+        out_channels=[256, 256],
+        upsample_strides=[1, 2],
+        norm_cfg=dict(type='BN', eps=1e-3, momentum=0.01),
+        upsample_cfg=dict(type='deconv', bias=False),
+        use_conv_for_no_stride=True),
+    pts_bbox_head=dict(
+        type='CenterHead',
+        in_channels=sum([256, 256]),
+        tasks=[
+            dict(num_class=1, class_names=['Car']),
+            dict(num_class=1, class_names=['Pedestrian']),
+            dict(num_class=1, class_names=['Cyclist']),
+        ],
+        common_heads=dict(reg=(2, 2), height=(1, 2), dim=(3, 2), rot=(2, 2)),
+        share_conv_channel=64,
+        bbox_coder=dict(
+            type='CenterPointBBoxCoder',
+            max_num=100,
+            score_threshold=0.1,
+            out_size_factor=8,
+            voxel_size=voxel_size[:2],
+            code_size=7,
+        ),
+        separate_head=dict(
+            type='SeparateHead', init_bias=-2.19, final_kernel=3),
+        loss_cls=dict(type='GaussianFocalLoss', reduction='mean'),
+        loss_bbox=dict(type='L1Loss', reduction='mean', loss_weight=0.25),
+        norm_bbox=True),
+    # model training and testing settings
+    train_cfg=dict(
+        pts=dict(
+            grid_size=[1408, 1600, 40],
+            voxel_size=voxel_size,
+            out_size_factor=8,
+            dense_reg=1,
+            gaussian_overlap=0.1,
+            max_objs=500,
+            min_radius=2,
+            code_weights=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])),
+    test_cfg=dict(
+        pts=dict(
+            max_per_img=500,
+            max_pool_nms=False,
+            min_radius=[4, 12, 10, 1, 0.85, 0.175],
+            score_threshold=0.1,
+            out_size_factor=4,
+            voxel_size=voxel_size[:2],
+            nms_type='rotate',
+            pre_max_size=4096,
+            post_max_size=512,
+            nms_thr=0.2)))

--- a/configs/centerpoint/centerpoint_01voxel_second_secfpn_4x8_cyclic_20e_kitti.py
+++ b/configs/centerpoint/centerpoint_01voxel_second_secfpn_4x8_cyclic_20e_kitti.py
@@ -1,0 +1,17 @@
+_base_ = [
+    '../_base_/datasets/kitti-3d-3class.py',
+    '../_base_/models/centerpoint_01voxel_second_secfpn_kitti.py',
+    '../_base_/schedules/cyclic_20e.py', '../_base_/default_runtime.py'
+]
+
+# If point cloud range is changed, the models should also change their point
+# cloud range accordingly
+point_cloud_range = [0, -40, -3, 70.4, 40, 1]
+
+# Add 'point_cloud_range' into model config according to dataset
+model = dict(
+    pts_voxel_layer=dict(point_cloud_range=point_cloud_range),
+    pts_bbox_head=dict(bbox_coder=dict(pc_range=point_cloud_range[:2])),
+    # model training and testing settings
+    train_cfg=dict(pts=dict(point_cloud_range=point_cloud_range)),
+    test_cfg=dict(pts=dict(pc_range=point_cloud_range[:2])))

--- a/configs/centerpoint/centerpoint_01voxel_second_secfpn_dcn_circlenms_4x8_cyclic_20e_kitti.py
+++ b/configs/centerpoint/centerpoint_01voxel_second_secfpn_dcn_circlenms_4x8_cyclic_20e_kitti.py
@@ -1,0 +1,16 @@
+_base_ = ['./centerpoint_01voxel_second_secfpn_4x8_cyclic_20e_kitti.py']
+
+model = dict(
+    pts_bbox_head=dict(
+        separate_head=dict(
+            type='DCNSeparateHead',
+            dcn_config=dict(
+                type='DCN',
+                in_channels=64,
+                out_channels=64,
+                kernel_size=3,
+                padding=1,
+                groups=4),
+            init_bias=-2.19,
+            final_kernel=3)),
+    test_cfg=dict(pts=dict(nms_type='circle')))

--- a/mmdet3d/models/dense_heads/centerpoint_head.py
+++ b/mmdet3d/models/dense_heads/centerpoint_head.py
@@ -455,6 +455,7 @@ class CenterHead(BaseModule):
         grid_size = torch.tensor(self.train_cfg['grid_size'])
         pc_range = torch.tensor(self.train_cfg['point_cloud_range'])
         voxel_size = torch.tensor(self.train_cfg['voxel_size'])
+        gt_annotation_num = len(self.train_cfg['code_weights'])
 
         feature_map_size = grid_size[:2] // self.train_cfg['out_size_factor']
 
@@ -489,7 +490,7 @@ class CenterHead(BaseModule):
                 (len(self.class_names[idx]), feature_map_size[1],
                  feature_map_size[0]))
 
-            anno_box = gt_bboxes_3d.new_zeros((max_objs, 10),
+            anno_box = gt_bboxes_3d.new_zeros((max_objs, gt_annotation_num),
                                               dtype=torch.float32)
 
             ind = gt_labels_3d.new_zeros((max_objs), dtype=torch.int64)
@@ -546,20 +547,29 @@ class CenterHead(BaseModule):
 
                     ind[new_idx] = y * feature_map_size[0] + x
                     mask[new_idx] = 1
-                    # TODO: support other outdoor dataset
-                    vx, vy = task_boxes[idx][k][7:]
+
                     rot = task_boxes[idx][k][6]
                     box_dim = task_boxes[idx][k][3:6]
                     if self.norm_bbox:
                         box_dim = box_dim.log()
-                    anno_box[new_idx] = torch.cat([
+
+                    anno_elems = [
                         center - torch.tensor([x, y], device=device),
                         z.unsqueeze(0), box_dim,
                         torch.sin(rot).unsqueeze(0),
-                        torch.cos(rot).unsqueeze(0),
-                        vx.unsqueeze(0),
-                        vy.unsqueeze(0)
-                    ])
+                        torch.cos(rot).unsqueeze(0)
+                    ]
+                    # Assumes datasets with bbox annotations with 9
+                    # values have two additional velocity components (vx, vy)
+                    # in addition to the standard KITTI-like 7 values
+                    # (H, W, L, x, y, z, rot).
+                    # NOTE: Rotation is split into two (sin, cos) components,
+                    # hence incrementing the annotation number by one.
+                    if gt_annotation_num == 10:
+                        vx, vy = task_boxes[idx][k][7:10]
+                        anno_elems += [vx.unsqueeze(0), vy.unsqueeze(0)]
+
+                    anno_box[new_idx] = torch.cat(anno_elems)
 
             heatmaps.append(heatmap)
             anno_boxes.append(anno_box)
@@ -592,12 +602,17 @@ class CenterHead(BaseModule):
                 heatmaps[task_id],
                 avg_factor=max(num_pos, 1))
             target_box = anno_boxes[task_id]
-            # reconstruct the anno_box from multiple reg heads
-            preds_dict[0]['anno_box'] = torch.cat(
-                (preds_dict[0]['reg'], preds_dict[0]['height'],
-                 preds_dict[0]['dim'], preds_dict[0]['rot'],
-                 preds_dict[0]['vel']),
-                dim=1)
+            # Reconstruct the anno_box from multiple reg heads
+            # Default keys assumed to exist for annotations with standard
+            # KITTI-like 7 values
+            anno_box = [
+                preds_dict[0]['reg'], preds_dict[0]['height'],
+                preds_dict[0]['dim'], preds_dict[0]['rot']
+            ]
+            # Key assumed to exist for bbox annotations with 9 values
+            if 'vel' in preds_dict[0]:
+                anno_box.append(preds_dict[0]['vel'])
+            preds_dict[0]['anno_box'] = torch.cat(anno_box, dim=1)
 
             # Regression loss for dimension, offset, height, rotation
             ind = inds[task_id]


### PR DESCRIPTION
This PR consists of two contributions
1. Modifies the code of CenterPoint's head (`mmdet3d/models/dense_heads/centerpoint_head.py`) to make it compatible with datasets having bbox annotations with 7 values (new, KITTI-like) or 9 values (current, nuScenes-like).
2. Adds KITTI configuration files for CenterPoint.

## Motivation

Currently, there exists no official implementation for KITTI with CenterPoint while several issues have requested an implementation (see https://github.com/open-mmlab/mmdetection3d/issues/486, https://github.com/open-mmlab/mmdetection3d/issues/225, https://github.com/open-mmlab/mmdetection3d/issues/190). KITTI is a standard benchmarking dataset, and think it is of value to be able to refer to an official implementation and benchmark results when comparing CenterPoint with other models.

## Modification

The code in`centerpoint_head.py` is restrained to how annotation bboxes are generated within two functions; `def get_targets_single()` and `def loss()`.

For `def get_targets_single()`, the number of bbox annotation elements is set dynamically according to the config file (i.e. `gt_annotation_num = len(self.train_cfg['code_weights']`). The `torch.Tensor` annotation box (`anno_box`) is created either as a 7 or 9 element tensor depending on `gt_annotation_num`.

For `def loss()`, the annotation box is restructured first based on universal elements, in addition to the velocity components `(vx, vy)` if such elements exist.

These changes allow `centerpoint_head.py` to work with both nuScenes and KITTI configurations without requiring any further code changes.

The new KITTI configuration file parameter values are the same as in https://github.com/open-mmlab/mmdetection3d/issues/871.

The modifications are currently being validated with two experiment runs; nuScenes is validated using the existing config file `centerpoint_0075voxel_second_secfpn_dcn_circlenms_4x8_cyclic_20e_nus.py`, and KITTI is validated using the new config file `centerpoint_01voxel_second_secfpn_dcn_circlenms_4x8_cyclic_20e_kitti.py`. Results will be reported once available.
