### PR TITLE
ADD Annotation bboxes for output visualization

### DIFF
--- a/mmdet3d/apis/test.py
+++ b/mmdet3d/apis/test.py
@@ -44,7 +44,9 @@ def single_gpu_test(model,
             models_3d = (Base3DDetector, Base3DSegmentor,
                          SingleStageMono3DDetector)
             if isinstance(model.module, models_3d):
-                model.module.show_results(data, result, out_dir=out_dir)
+                gt_bboxes = data_loader.dataset.get_ann_info(i)['gt_bboxes_3d']
+                model.module.show_results(
+                    data, result, out_dir=out_dir, gt_bboxes=gt_bboxes)
             # Visualize the results of MMDetection model
             # 'show_result' is MMdetection visualization API
             else:

--- a/mmdet3d/models/detectors/base.py
+++ b/mmdet3d/models/detectors/base.py
@@ -60,13 +60,14 @@ class Base3DDetector(BaseDetector):
         else:
             return self.forward_test(**kwargs)
 
-    def show_results(self, data, result, out_dir):
+    def show_results(self, data, result, out_dir, gt_bboxes=None):
         """Results visualization.
 
         Args:
             data (list[dict]): Input points and the information of the sample.
             result (list[dict]): Prediction results.
             out_dir (str): Output directory of visualization result.
+            gt_bboxes (obj:`LIDARInstance3DBoxes): GT bbox annotations.
         """
         for batch_id in range(len(result)):
             if isinstance(data['points'][0], DC):
@@ -101,8 +102,12 @@ class Base3DDetector(BaseDetector):
                                                    Coord3DMode.DEPTH)
                 pred_bboxes = Box3DMode.convert(pred_bboxes, box_mode_3d,
                                                 Box3DMode.DEPTH)
+                gt_bboxes = Box3DMode.convert(gt_bboxes, box_mode_3d,
+                                              Box3DMode.DEPTH)
             elif box_mode_3d != Box3DMode.DEPTH:
                 ValueError(
                     f'Unsupported box_mode_3d {box_mode_3d} for convertion!')
             pred_bboxes = pred_bboxes.tensor.cpu().numpy()
-            show_result(points, None, pred_bboxes, out_dir, file_name)
+            if gt_bboxes is not None:
+                gt_bboxes = gt_bboxes.tensor.cpu().numpy()
+            show_result(points, gt_bboxes, pred_bboxes, out_dir, file_name)

--- a/mmdet3d/models/detectors/base.py
+++ b/mmdet3d/models/detectors/base.py
@@ -102,8 +102,9 @@ class Base3DDetector(BaseDetector):
                                                    Coord3DMode.DEPTH)
                 pred_bboxes = Box3DMode.convert(pred_bboxes, box_mode_3d,
                                                 Box3DMode.DEPTH)
-                gt_bboxes = Box3DMode.convert(gt_bboxes, box_mode_3d,
-                                              Box3DMode.DEPTH)
+                if gt_bboxes is not None:
+                    gt_bboxes = Box3DMode.convert(gt_bboxes, box_mode_3d,
+                                                  Box3DMode.DEPTH)
             elif box_mode_3d != Box3DMode.DEPTH:
                 ValueError(
                     f'Unsupported box_mode_3d {box_mode_3d} for convertion!')

--- a/mmdet3d/models/detectors/mvx_two_stage.py
+++ b/mmdet3d/models/detectors/mvx_two_stage.py
@@ -496,8 +496,9 @@ class MVXTwoStageDetector(Base3DDetector):
                                                    Coord3DMode.DEPTH)
                 pred_bboxes = Box3DMode.convert(pred_bboxes, box_mode_3d,
                                                 Box3DMode.DEPTH)
-                gt_bboxes = Box3DMode.convert(gt_bboxes, box_mode_3d,
-                                              Box3DMode.DEPTH)
+                if gt_bboxes is not None:
+                    gt_bboxes = Box3DMode.convert(gt_bboxes, box_mode_3d,
+                                                  Box3DMode.DEPTH)
             elif box_mode_3d != Box3DMode.DEPTH:
                 ValueError(
                     f'Unsupported box_mode_3d {box_mode_3d} for convertion!')

--- a/mmdet3d/models/detectors/mvx_two_stage.py
+++ b/mmdet3d/models/detectors/mvx_two_stage.py
@@ -454,13 +454,14 @@ class MVXTwoStageDetector(Base3DDetector):
                                             self.pts_bbox_head.test_cfg)
         return merged_bboxes
 
-    def show_results(self, data, result, out_dir):
+    def show_results(self, data, result, out_dir, gt_bboxes=None):
         """Results visualization.
 
         Args:
             data (dict): Input points and the information of the sample.
             result (dict): Prediction results.
             out_dir (str): Output directory of visualization result.
+            gt_bboxes (obj:`LIDARInstance3DBoxes): GT bbox annotations.
         """
         for batch_id in range(len(result)):
             if isinstance(data['points'][0], DC):
@@ -495,9 +496,13 @@ class MVXTwoStageDetector(Base3DDetector):
                                                    Coord3DMode.DEPTH)
                 pred_bboxes = Box3DMode.convert(pred_bboxes, box_mode_3d,
                                                 Box3DMode.DEPTH)
+                gt_bboxes = Box3DMode.convert(gt_bboxes, box_mode_3d,
+                                              Box3DMode.DEPTH)
             elif box_mode_3d != Box3DMode.DEPTH:
                 ValueError(
                     f'Unsupported box_mode_3d {box_mode_3d} for convertion!')
 
             pred_bboxes = pred_bboxes.tensor.cpu().numpy()
-            show_result(points, None, pred_bboxes, out_dir, file_name)
+            if gt_bboxes is not None:
+                gt_bboxes = gt_bboxes.tensor.cpu().numpy()
+            show_result(points, gt_bboxes, pred_bboxes, out_dir, file_name)

--- a/mmdet3d/models/detectors/single_stage_mono3d.py
+++ b/mmdet3d/models/detectors/single_stage_mono3d.py
@@ -178,13 +178,14 @@ class SingleStageMono3DDetector(SingleStageDetector):
 
         return [bbox_list]
 
-    def show_results(self, data, result, out_dir):
+    def show_results(self, data, result, out_dir, gt_bboxes=None):
         """Results visualization.
 
         Args:
             data (list[dict]): Input images and the information of the sample.
             result (list[dict]): Prediction results.
             out_dir (str): Output directory of visualization result.
+            gt_bboxes (obj:`LIDARInstance3DBoxes): GT bbox annotations.
         """
         for batch_id in range(len(result)):
             if isinstance(data['img_metas'][0], DC):
@@ -209,7 +210,7 @@ class SingleStageMono3DDetector(SingleStageDetector):
 
             show_multi_modality_result(
                 img,
-                None,
+                gt_bboxes,
                 pred_bboxes,
                 cam2img,
                 out_dir,


### PR DESCRIPTION
This PR adds functionality for test visualization to display ground truth annotation bboxes in addition to prediction bboxes.

For sparse point clouds it can be challenging to visually confirm if a prediction is correct or not. Adding in the ground truth annotation bboxes (blue) in addition to the predicted bboxes (green) greatly improves the interpretability of the model's prediction performance.

This functionality has been requested in prior issues such as https://github.com/open-mmlab/mmdetection3d/issues/222 and can be used without any change in configuration files or CLI arguments.

## Modification
First, the ground truth annotation bboxes for a sample is extracted in the visualization code (mmdet3d/apis/test.py) through the pre-existing data_loader object.

`gt_bboxes = data_loader.dataset.get_ann_info(i)['gt_bboxes_3d']`

Secondly, the `show_results()` function in all detection model takes an additional optional argument for the gt_bboxes object.

`model.module.show_results(data, result, out_dir=out_dir, gt_bboxes=gt_bboxes)`

 If no gt_bboxes object is supplied, the default None value results in the original function execution flow.

Finally, the `show_multi_modality_result()` function is already compatible with the gt_bboxes object and successfully visualizes the annotations.

## Visualization example

Model: CenterPoint
Dataset: KITTI
Predictions: Green
GT annotations: Blue

![Screenshot from 2021-10-02 15-02-42](https://user-images.githubusercontent.com/34254153/135707135-c65bb203-aaf7-4a47-af0e-7c40a7bf2948.png)
![Screenshot from 2021-10-02 15-41-54](https://user-images.githubusercontent.com/34254153/135707139-8211d9f3-1230-4136-ac46-bd4c39249ff3.png)


