### PR TITLE
[Fix] Fix default show value in show_result function and a typo in waymo_data_prep

### DIFF
--- a/mmdet3d/core/visualizer/show_result.py
+++ b/mmdet3d/core/visualizer/show_result.py
@@ -77,7 +77,7 @@ def show_result(points,
                 pred_bboxes,
                 out_dir,
                 filename,
-                show=True,
+                show=False,
                 snapshot=False):
     """Convert results into format that is directly readable for meshlab.
 

--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -169,7 +169,7 @@ def waymo_data_prep(root_path,
             save_dir,
             prefix=str(i),
             workers=workers,
-            test_mode=(split == 'test'))
+            test_mode=(split == 'testing'))
         converter.convert()
     # Generate waymo infos
     out_dir = osp.join(out_dir, 'kitti_format')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. Incorrect default value for show_result proposed buy #1032 
2. While converting Waymo test data set, the split is wrong, proposed by #1016 

## Modification
1. Change the default value in show_result func to be consistent with docstring.
2. change ` test_mode=(split == 'test')) ` to ` test_mode=(split == 'testing')) `.

## BC-breaking (Optional)
no

## Use cases (Optional)
n/a

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
