### PR TITLE
[Fix] Fix incorrect velo indexing when formatting boxes on nuScenes

### DIFF
--- a/mmdet3d/datasets/nuscenes_mono_dataset.py
+++ b/mmdet3d/datasets/nuscenes_mono_dataset.py
@@ -776,7 +776,7 @@ def nusc_box_to_cam_box3d(boxes):
     dims = torch.Tensor([b.wlh for b in boxes]).view(-1, 3)
     rots = torch.Tensor([b.orientation.yaw_pitch_roll[0]
                          for b in boxes]).view(-1, 1)
-    velocity = torch.Tensor([b.velocity[:2] for b in boxes]).view(-1, 2)
+    velocity = torch.Tensor([b.velocity[0::2] for b in boxes]).view(-1, 2)
 
     # convert nusbox to cambox convention
     dims[:, [0, 1, 2]] = dims[:, [1, 2, 0]]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix incorrect velocity indexing when formatting boxes on nuScenes.
Note that this fix can affect the specific evaluation result for mAVE but won't affect the final NDS because mAVE is usually larger than 1 for monocular 3D detectors (at least not affect the currently supported mono3D models).

## Modification

Only fix the incorrect velocity indexing when changing nuscenes boxes to `CameraInstance3DBoxes`.

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
