### PR TITLE
Add PGD to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install mmsegmentation==0.18.0
 
 # Install MMDetection3D
 RUN conda clean --all
-RUN git clone https://github.com/open-mmlab/mmdetection3d.git /mmdetection3d
+COPY . /mmdetection3d
 WORKDIR /mmdetection3d
 ENV FORCE_CUDA="1"
 RUN pip install -r requirements/build.txt

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -169,7 +169,7 @@ We provide a [Dockerfile](https://github.com/open-mmlab/mmdetection3d/blob/maste
 
 ```shell
 # build an image with PyTorch 1.6, CUDA 10.1
-docker build -t mmdetection3d docker/
+docker build -t mmdetection3d -f docker/Dockerfile .
 ```
 
 Run it with

--- a/model-index.yml
+++ b/model-index.yml
@@ -17,3 +17,4 @@ Import:
   - configs/votenet/metafile.yml
   - configs/fcos3d/metafile.yml
   - configs/imvoxelnet/metafile.yml
+  - configs/pgd/metafile.yml


### PR DESCRIPTION
## Motivation
It would be nice to be able to play with bleeding edge features when using docker, but currently this is not possible. For example, PGD config is missing from docker image, because code in master is cloned.

## Modification
Instead of cloning the master branch in Dockerfile, now we just copy the repository contents. In v1.0.0-dev0 branch, we can see PGA in Docker container, because contents of the current branch are copied. Sine copying cannot be done outside docker build context, the build command had to be modified a bit by adding the -f option as shown in the .md-file.

## BC-breaking (Optional)
I don't see this as a breaking change. If there are CI builds that try to build the docker image in this repo, then the build commands in CI-yml files may need update. (But only if v1.0.0-dev0 gets merged to master).

## Use cases (Optional)
-

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
