### PR TITLE
[Fix]fix init_model to support 'device=cpu'

### DIFF
--- a/mmdet3d/apis/inference.py
+++ b/mmdet3d/apis/inference.py
@@ -71,8 +71,8 @@ def init_model(config, checkpoint=None, device='cuda:0'):
         torch.cuda.set_device(device)
     else:
         logger = get_root_logger()
-        logger.warning(
-            'Don\'t suggest using CPU device. Some func can\'t support.')
+        logger.warning('Don\'t suggest using CPU device. '
+                       'Some functions are not supported for now.')
     model.to(device)
     model.eval()
     return model

--- a/mmdet3d/apis/inference.py
+++ b/mmdet3d/apis/inference.py
@@ -16,6 +16,7 @@ from mmdet3d.core import (Box3DMode, CameraInstance3DBoxes, Coord3DMode,
 from mmdet3d.core.bbox import get_box_type
 from mmdet3d.datasets.pipelines import Compose
 from mmdet3d.models import build_model
+from mmdet3d.utils import get_root_logger
 
 
 def convert_SyncBN(config):
@@ -66,7 +67,12 @@ def init_model(config, checkpoint=None, device='cuda:0'):
         if 'PALETTE' in checkpoint['meta']:  # 3D Segmentor
             model.PALETTE = checkpoint['meta']['PALETTE']
     model.cfg = config  # save the config in the model for convenience
-    torch.cuda.set_device(device)
+    if device != 'cpu':
+        torch.cuda.set_device(device)
+    else:
+        logger = get_root_logger()
+        logger.warning(
+            'Don\'t suggest using CPU device. Some func can\'t support.')
     model.to(device)
     model.eval()
     return model


### PR DESCRIPTION
## Motivation
Hello, when I support mmdet3d in mmdeploy, I find if my device == 'cpu', error:
`Traceback (most recent call last):
  File "/home/PJLAB/shenkun/workspace/mmdetection3d/demo/pcd_demo.py", line 44, in <module>
    main()
  File "/home/PJLAB/shenkun/workspace/mmdetection3d/demo/pcd_demo.py", line 29, in main
    model = init_model(args.config, args.checkpoint, device=args.device)
  File "/home/PJLAB/shenkun/workspace/mmdetection3d/mmdet3d/apis/inference.py", line 76, in init_model
    torch.cuda.set_device(device)
  File "/home/PJLAB/shenkun/anaconda3/envs/pt1.8/lib/python3.8/site-packages/torch/cuda/__init__.py", line 259, in set_device
    device = _get_device_index(device)
  File "/home/PJLAB/shenkun/anaconda3/envs/pt1.8/lib/python3.8/site-packages/torch/cuda/_utils.py", line 31, in _get_device_index
    raise ValueError('Expected a cuda device, but got: {}'.format(device))
ValueError: Expected a cuda device, but got: cpu`

## Modification
mmdet3d/apis/inference.py

