### PR TITLE
[Fix] show_pipeline in browse_dataset.py does not collect gt_boxes

### DIFF
--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -104,7 +104,6 @@ def show_det_data(input, out_dir, show=False):
     """Visualize 3D point cloud and 3D bboxes."""
     img_metas = input['img_metas']._data
     points = input['points']._data.numpy()
-    # input_dict['bbox3d_fields']
     gt_bboxes = input['gt_bboxes_3d']._data.tensor
     if img_metas['box_mode_3d'] != Box3DMode.DEPTH:
         points, gt_bboxes = to_depth_mode(points, gt_bboxes)

--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -79,6 +79,8 @@ def build_data_cfg(config_path, skip_type, aug, cfg_options):
         for i in range(len(cfg.train_pipeline)):
             if cfg.train_pipeline[i]['type'] == 'LoadAnnotations3D':
                 show_pipeline.insert(i, cfg.train_pipeline[i])
+        # Collect points as well as labels
+        show_pipeline[-1] = cfg.train_pipeline[-1]
 
     train_data_cfg['pipeline'] = [
         x for x in show_pipeline if x['type'] not in skip_type
@@ -102,6 +104,7 @@ def show_det_data(input, out_dir, show=False):
     """Visualize 3D point cloud and 3D bboxes."""
     img_metas = input['img_metas']._data
     points = input['points']._data.numpy()
+    # input_dict['bbox3d_fields']
     gt_bboxes = input['gt_bboxes_3d']._data.tensor
     if img_metas['box_mode_3d'] != Box3DMode.DEPTH:
         points, gt_bboxes = to_depth_mode(points, gt_bboxes)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
```
python tools/misc/browse_dataset.py configs/_base_/datasets/kitti-3d-3class.py --task det --output-dir tmp --online
```
gives error
```
  File "tools/misc/browse_dataset.py", line 226, in <module>
    main()
  File "tools/misc/browse_dataset.py", line 211, in main
    show_det_data(input, args.output_dir, show=args.online)
  File "tools/misc/browse_dataset.py", line 105, in show_det_data
    gt_bboxes = input['gt_bboxes_3d']._data.tensor
KeyError: 'gt_bboxes_3d'
```

## Modification
Show-pipeline is copied from eval pipeline, whose `Collect` does not collect ground truth. 

## BC-breaking (Optional)
Possibly.
I am not able to test other datasets. 

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
