### PR TITLE
fix bbox direction

### DIFF
--- a/mmdet3d/models/dense_heads/anchor3d_head.py
+++ b/mmdet3d/models/dense_heads/anchor3d_head.py
@@ -511,7 +511,7 @@ class Anchor3DHead(BaseModule, AnchorTrainMixin):
             dir_rot = limit_period(bboxes[..., 6] - self.dir_offset,
                                    self.dir_limit_offset, np.pi)
             bboxes[..., 6] = (
-                dir_rot + self.dir_offset +
-                np.pi * (1 - dir_scores.to(bboxes.dtype)))
+                dir_rot + self.dir_offset + np.pi *
+                (1 - dir_scores.to(bboxes.dtype)))
         bboxes = input_meta['box_type_3d'](bboxes, box_dim=self.box_code_size)
         return bboxes, scores, labels

--- a/mmdet3d/models/dense_heads/anchor3d_head.py
+++ b/mmdet3d/models/dense_heads/anchor3d_head.py
@@ -512,6 +512,6 @@ class Anchor3DHead(BaseModule, AnchorTrainMixin):
                                    self.dir_limit_offset, np.pi)
             bboxes[..., 6] = (
                 dir_rot + self.dir_offset +
-                np.pi * dir_scores.to(bboxes.dtype))
+                np.pi * (1 - dir_scores.to(bboxes.dtype)))
         bboxes = input_meta['box_type_3d'](bboxes, box_dim=self.box_code_size)
         return bboxes, scores, labels


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When training PointPillars, the bbox direction gt label is set to 0 when the angle is between in [0, np.pi] and  is set to 1 when the angle is between in [np.pi, 2*np.pi]. 

https://github.com/open-mmlab/mmdetection3d/blob/ed81c6cc326a33f927d4455c219bb7715591b08b/mmdet3d/models/dense_heads/train_mixins.py#L336-L338

However, in the test stage, the operation may be opposite. That is the predicted label 0 corresponds to [-np.pi, 0] or [np.pi, 2*np.pi], while the predicted label 1 corresponds to [0, np.pi]

https://github.com/open-mmlab/mmdetection3d/blob/ed81c6cc326a33f927d4455c219bb7715591b08b/mmdet3d/models/dense_heads/anchor3d_head.py#L506-L511

## Modification

I modified in predicted bbox prediction ([mmdet3d/models/dense_heads/anchor3d_head.py#L506-L511](https://github.com/open-mmlab/mmdetection3d/blob/ed81c6cc326a33f927d4455c219bb7715591b08b/mmdet3d/models/dense_heads/anchor3d_head.py#L506-L511)) as the following code:

```
if bboxes.shape[0] > 0:
            dir_rot = limit_period(bboxes[..., 6] - self.dir_offset,
                                   self.dir_limit_offset, np.pi)
            bboxes[..., 6] = (
                dir_rot + self.dir_offset + np.pi *
                (1 - dir_scores.to(bboxes.dtype)))
```

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
