### PR TITLE
Fixed missing __init__ files

### DIFF
--- a/mmdet3d/core/evaluation/scannet_utils/__init__.py
+++ b/mmdet3d/core/evaluation/scannet_utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .evaluate_semantic_instance import evaluate_matches, scannet_eval
+
+__all__ = ['scannet_eval', 'evaluate_matches']

--- a/mmdet3d/core/evaluation/waymo_utils/__init__.py
+++ b/mmdet3d/core/evaluation/waymo_utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .prediction_kitti_to_waymo import KITTI2Waymo
+
+__all__ = ['KITTI2Waymo']


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
The new v1.0.rc1 update has a bug where there are no __init__.py files for scannet_utils or waymo_utils. This was mentioned in #1378. Despite  scannet_utils or waymo_utils being in the repo, when mmdet3d is pip installed those directories are not picked up. This caused a break in a couple of places including ```init_model``` and ```tools/create_dataset.py```

## Modification
I created __init__.py files for scannet_utils/ and waymo_utils/ that follow the same conventions as the kitti_utils/__init__.py file.

## BC-breaking (Optional)
This does not break back-stream compatibility.

## Use cases (Optional)
No new features

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
