### PR TITLE
[Fix]fix bug about box visualize yaw

### DIFF
--- a/mmdet3d/core/visualizer/open3d_vis.py
+++ b/mmdet3d/core/visualizer/open3d_vis.py
@@ -95,7 +95,7 @@ def _draw_bboxes(bbox3d,
         center = bbox3d[i, 0:3]
         dim = bbox3d[i, 3:6]
         yaw = np.zeros(3)
-        yaw[rot_axis] = -bbox3d[i, 6]
+        yaw[rot_axis] = bbox3d[i, 6]
         rot_mat = geometry.get_rotation_matrix_from_xyz(yaw)
 
         if center_mode == 'lidar_bottom':


### PR DESCRIPTION
## Motivation
Fix a bug about visualize yaw. When I visualize pointpillars by `demo/pcd_demo.py`, I find box yaw is erred and then I fix it.

## Modification
Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)
None

## Use cases (Optional)
python demo/pcd_demo.py demo/data/kitti/kitti_000008.bin
configs/pointpillars/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class.py
https://download.openmmlab.com/mmdetection3d/v1.0.0_models/pointpillars/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class_20220301_150306-37dc2420.pth
--show
--device
cuda:0

