### PR TITLE
[Bug]fix mmdet bc breaking

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -19,7 +19,7 @@ from mmdet.apis import multi_gpu_test, set_random_seed
 from mmdet.datasets import replace_ImageToTensor
 
 if mmdet.__version__ > '2.23.0':
-    # If mmdet version > 2.24.0, setup_multi_processes would be imported and
+    # If mmdet version > 2.23.0, setup_multi_processes would be imported and
     # used from mmdet instead of mmdet3d.
     from mmdet.utils import setup_multi_processes
 else:

--- a/tools/test.py
+++ b/tools/test.py
@@ -11,17 +11,18 @@ from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
                          wrap_fp16_model)
 
+import mmdet
 from mmdet3d.apis import single_gpu_test
 from mmdet3d.datasets import build_dataloader, build_dataset
 from mmdet3d.models import build_model
 from mmdet.apis import multi_gpu_test, set_random_seed
 from mmdet.datasets import replace_ImageToTensor
 
-try:
-    # If mmdet version > 2.20.0, setup_multi_processes would be imported and
+if mmdet.__version__ > '2.23.0':
+    # If mmdet version > 2.24.0, setup_multi_processes would be imported and
     # used from mmdet instead of mmdet3d.
     from mmdet.utils import setup_multi_processes
-except ImportError:
+else:
     from mmdet3d.utils import setup_multi_processes
 
 


### PR DESCRIPTION
## Motivation
After pr #1388, if the user installed mmdet version is not the newest, err:
```
Traceback (most recent call last):
File "tools/test.py", line 259, in
main()
File "tools/test.py", line 151, in main
setup_multi_processes(cfg)
File "/home//.local/lib/python3.8/site-packages/mmdet/utils/setup_env.py", line 30, in setup_multi_processes
if 'OMP_NUM_THREADS' not in os.environ and cfg.data.workers_per_gpu > 1:
File "/home/*/.local/lib/python3.8/site-packages/mmcv/utils/config.py", line 49, in getattr
raise ex
```

## Modification
fix test.py to import setup_multi_processes from mmdet3d to resolve back-compatibility.

