### PR TITLE
[DOC]Configure Myst-parser to parse anchor tag

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -136,11 +136,11 @@ latex_documents = [
 StandaloneHTMLBuilder.supported_image_types = [
     'image/svg+xml', 'image/gif', 'image/png', 'image/jpeg'
 ]
-# -- Extension configuration -------------------------------------------------
-# Ignore >>> when copying code
-copybutton_prompt_text = r'>>> |\.\.\. '
-copybutton_prompt_is_regexp = True
+# Enable ::: for my_st
+myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 3
 
+language = 'en'
 
 def builder_inited_handler(app):
     subprocess.run(['./stat.py'])

--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -142,6 +142,7 @@ myst_heading_anchors = 3
 
 language = 'en'
 
+
 def builder_inited_handler(app):
     subprocess.run(['./stat.py'])
 


### PR DESCRIPTION
By default, myst-parser did not parse links to anchor tags in markdown files, making these hyperlinks become raw texts in docs. This PR updates myst's configuration to enable this feature.

related PR https://github.com/open-mmlab/mmrotate/pull/305