### PR TITLE
[Fix] Fixed bug on Custom3DDataset

### DIFF
--- a/mmdet3d/datasets/custom_3d.py
+++ b/mmdet3d/datasets/custom_3d.py
@@ -182,7 +182,7 @@ class Custom3DDataset(Dataset):
             origin=(0.5, 0.5, 0.5)).convert_to(self.box_mode_3d)
 
         anns_results = dict(
-            gt_bboxes_3d=gt_bboxes_3d, gt_labels_3d=gt_labels_3d)
+            gt_bboxes_3d=gt_bboxes_3d, gt_labels_3d=gt_labels_3d, gt_names=gt_names_3d)
         return anns_results
 
     def pre_pipeline(self, results):

--- a/mmdet3d/datasets/custom_3d.py
+++ b/mmdet3d/datasets/custom_3d.py
@@ -182,7 +182,9 @@ class Custom3DDataset(Dataset):
             origin=(0.5, 0.5, 0.5)).convert_to(self.box_mode_3d)
 
         anns_results = dict(
-            gt_bboxes_3d=gt_bboxes_3d, gt_labels_3d=gt_labels_3d, gt_names=gt_names_3d)
+            gt_bboxes_3d=gt_bboxes_3d,
+            gt_labels_3d=gt_labels_3d,
+            gt_names=gt_names_3d)
         return anns_results
 
     def pre_pipeline(self, results):


### PR DESCRIPTION
The function [`get_ann_info`](https://github.com/open-mmlab/mmdetection3d/blob/14c5ded49dd5df7a52368bd54c32a003c2521e1d/mmdet3d/datasets/custom_3d.py#L149) in [Custom3DDataset](https://github.com/open-mmlab/mmdetection3d/blob/14c5ded49dd5df7a52368bd54c32a003c2521e1d/mmdet3d/datasets/custom_3d.py#L17) is supposed to return a dict with the following keys (it says it also in the function's documentation): `gt_bboxes_3d`, `gt_labels_3d`, `gt_names`, but `gt_names `wasn't included in the return dict.

I was trying to add a custom dataset in mmdetection3d, and I was getting this KeyError telling me that there wasn't the key "gt_names" in the annotations.
The error was coming from [this line](https://github.com/open-mmlab/mmdetection3d/blob/master/tools/data_converter/create_gt_database.py#L245) in `create_gt_database.py` and I found out that the reason was that [`get_ann_info`](https://github.com/open-mmlab/mmdetection3d/blob/14c5ded49dd5df7a52368bd54c32a003c2521e1d/mmdet3d/datasets/custom_3d.py#L149) in [Custom3DDataset](https://github.com/open-mmlab/mmdetection3d/blob/14c5ded49dd5df7a52368bd54c32a003c2521e1d/mmdet3d/datasets/custom_3d.py#L17) was not including `gt_names` in the keys of the dict it was returning.

I added this key-value couple to the return dict of [`get_ann_info`](https://github.com/open-mmlab/mmdetection3d/blob/14c5ded49dd5df7a52368bd54c32a003c2521e1d/mmdet3d/datasets/custom_3d.py#L149) in [Custom3DDataset](https://github.com/open-mmlab/mmdetection3d/blob/14c5ded49dd5df7a52368bd54c32a003c2521e1d/mmdet3d/datasets/custom_3d.py#L17)

---

P.S. Unfortunately I had problems with the pre_commit procedure, I wasn't able to make it work, but my change is so small that I don't think the code needs to be restyled. Anyway, in case you can restyle it and add a commit on top of mine.