### PR TITLE
[Fix] Flip yaw angle for DepthInstance3DBoxes.overlaps

### DIFF
--- a/mmdet3d/core/bbox/structures/depth_box3d.py
+++ b/mmdet3d/core/bbox/structures/depth_box3d.py
@@ -268,3 +268,32 @@ class DepthInstance3DBoxes(BaseInstance3DBoxes):
         line_center = center.repeat(1, 12, 1).reshape(-1, 3) + line_3d
 
         return surface_center, line_center
+
+    @classmethod
+    def overlaps(cls, boxes1, boxes2, mode='iou'):
+        """Calculate 3D overlaps of two boxes.
+
+        Note:
+            This function calculates the overlaps between ``boxes1`` and
+            ``boxes2``, ``boxes1`` and ``boxes2`` should be in the same type.
+        Args:
+            boxes1 (:obj:`BaseInstance3DBoxes`): Boxes 1 contain N boxes.
+            boxes2 (:obj:`BaseInstance3DBoxes`): Boxes 2 contain M boxes.
+            mode (str, optional): Mode of iou calculation. Defaults to 'iou'.
+        Returns:
+            torch.Tensor: Calculated 3D overlaps of the boxes.
+        """
+        # We flip yaw angle here as mmcv.ops.box_iou_rotated accepts
+        # it in anti-clockwise direction.
+        if boxes1.with_yaw:
+            tensor1 = torch.cat(
+                (boxes1.tensor[:, :-1], -boxes1.tensor[:, -1:]), dim=-1)
+            boxes1 = DepthInstance3DBoxes(
+                tensor1, box_dim=boxes1.box_dim, with_yaw=boxes1.with_yaw)
+        if boxes2.with_yaw:
+            tensor2 = torch.cat(
+                (boxes2.tensor[:, :-1], -boxes2.tensor[:, -1:]), dim=-1)
+            boxes2 = DepthInstance3DBoxes(
+                tensor2, box_dim=boxes2.box_dim, with_yaw=boxes2.with_yaw)
+
+        return super().overlaps(boxes1, boxes2)


### PR DESCRIPTION
## Motivation
This fix is separated from FCAF3D PR #1547 after a small discussion with @ZwwWayne.

While working on that PR I've checked my FCAF3D checkpoints for ScanNet, SUN RGB-D and S3DIS from `mmdetectiontion3d==0.15.0`. And for ScanNet and S3DIS metrics were exactly the same, unlike SUN RGB-D with mAP@0.5 less then expected by ~3%. After some debugging I saw that the model is fine, but the difference is caused by the evaluation function. And basically the difference is in `BaseInstance3DBoxes.overlaps`. The difference is not that big, i.e. `test_indoor_eval` successfully passes with this fix and without it. But, maybe it is a bug.

As I understand we call `mmcv.ops.box_iou_rotated` in `BaseInstance3DBoxes.overlaps` and this function is designed for anti-clockwise heading angle. So it is probably ok for `LidarInstance3DBoxes`. But for `DepthInstance3DBoxes` the yaw angle is clockwise, so we need to flip the angle of `boxes1` and `boxes1` before calling `mmcv.ops.box_iou_rotated`.

Also the issue is critical as it has a little affect on `indoor_eval` and сonsequently on all indoor models. I have tried the VoteNet checkpoint  and the affect of this PR is minimal, e.g. <1% . However looks like VoteNet is 15% mAP@0.5 less than it should be in current `dev` branch. I'm not sure about the reason. May be it should be retrained, or the bug is introduced in `nms3d` or `iou3d` refactoring in last 2 months.

## Modification
Inherit `DepthInstance3DBoxes.overlaps` from `BaseInstance3DBoxes.overlaps`.

## BC-breaking
Yes.

