### PR TITLE
[Enhance] Remove 50000 points sampling from SUN RGB-D preprocessing

### DIFF
--- a/data/sunrgbd/README.md
+++ b/data/sunrgbd/README.md
@@ -27,9 +27,7 @@ NOTE: SUNRGBDtoolbox.zip should have MD5 hash `18d22e1761d36352f37232cba102f91f`
 
 NOTE: If you would like to play around with [ImVoteNet](../../configs/imvotenet/README.md), the image data (`./data/sunrgbd/sunrgbd_trainval/image`) are required. If you pre-processed the data before mmdet3d version 0.12.0, please pre-process the data again due to some updates in data pre-processing
 
-```bash
-python tools/create_data.py sunrgbd --root-path ./data/sunrgbd  --out-dir ./data/sunrgbd --extra-tag sunrgbd
-```
+NOTE: Before mmdet3d version 1.0.0 we sampled 50000 points following VoteNet preprocessing. On training and evaluation we use `PointSample` to sample the amount of points needed for each detector e.g. 20000 for VoteNet and GroupFree. However, modern voxel-based detectors (e.g. FCAF3D) utilize 100000 points and are able to utilize all of them. So since 1.0.0 version we do not limit the maximum number of points during preprocessing, giving the users more flexibility with `PointSample`. If you have some reasons to keep only 50000 points here please set `--num-points=50000` for `create_data.py`.
 
 The directory structure after pre-processing should be as below
 

--- a/docs/en/compatibility.md
+++ b/docs/en/compatibility.md
@@ -1,3 +1,11 @@
+## v1.0.0rc4
+
+### Number of points in SUN RGB-D preprocessing
+
+Before mmdet3d version 1.0.0rc4 we sampled 50000 points following VoteNet preprocessing. Since 1.0.0v4 version we do not limit the maximum number of points during preprocessing, giving the users more flexibility with `PointSample`. The SUN RGB-D annotations should be updated in case the user wants to achieve best metrics for models supporting more than 50000 input points.
+
+Please refer to the SUN RGB-D [README.md](https://github.com/open-mmlab/mmdetection3d/blob/master/data/sunrgbd/README.md/) for more details.
+
 ## v1.0.0rc1
 
 ### Operators Migration

--- a/docs/en/datasets/sunrgbd_det.md
+++ b/docs/en/datasets/sunrgbd_det.md
@@ -139,11 +139,9 @@ The above point cloud data are further saved in `.bin` format. Meanwhile `.pkl` 
 def process_single_scene(sample_idx):
     print(f'{self.split} sample_idx: {sample_idx}')
     # convert depth to points
-    # and downsample the points
-    SAMPLE_NUM = 50000
     pc_upright_depth = self.get_depth(sample_idx)
     pc_upright_depth_subsampled = random_sampling(
-        pc_upright_depth, SAMPLE_NUM)
+        pc_upright_depth, self.num_points)
 
     info = dict()
     pc_info = {'num_features': 6, 'lidar_idx': sample_idx}

--- a/docs/zh_cn/datasets/sunrgbd_det.md
+++ b/docs/zh_cn/datasets/sunrgbd_det.md
@@ -139,10 +139,9 @@ bash tools/create_data.sh <job_name> sunrgbd
 def process_single_scene(sample_idx):
     print(f'{self.split} sample_idx: {sample_idx}')
     # 将深度图转换为点云并降采样点云
-    SAMPLE_NUM = 50000
     pc_upright_depth = self.get_depth(sample_idx)
     pc_upright_depth_subsampled = random_sampling(
-        pc_upright_depth, SAMPLE_NUM)
+        pc_upright_depth, self.num_points)
 
     info = dict()
     pc_info = {'num_features': 6, 'lidar_idx': sample_idx}

--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -134,7 +134,7 @@ def s3dis_data_prep(root_path, info_prefix, out_dir, workers):
         root_path, info_prefix, out_dir, workers=workers)
 
 
-def sunrgbd_data_prep(root_path, info_prefix, out_dir, workers):
+def sunrgbd_data_prep(root_path, info_prefix, out_dir, workers, num_points):
     """Prepare the info file for sunrgbd dataset.
 
     Args:
@@ -144,7 +144,11 @@ def sunrgbd_data_prep(root_path, info_prefix, out_dir, workers):
         workers (int): Number of threads to be used.
     """
     indoor.create_indoor_info_file(
-        root_path, info_prefix, out_dir, workers=workers)
+        root_path,
+        info_prefix,
+        out_dir,
+        workers=workers,
+        num_points=num_points)
 
 
 def waymo_data_prep(root_path,
@@ -217,6 +221,11 @@ parser.add_argument(
     '--with-plane',
     action='store_true',
     help='Whether to use plane information for kitti.')
+parser.add_argument(
+    '--num-points',
+    type=int,
+    default=-1,
+    help='Number of points to sample for indoor datasets.')
 parser.add_argument(
     '--out-dir',
     type=str,
@@ -299,5 +308,6 @@ if __name__ == '__main__':
         sunrgbd_data_prep(
             root_path=args.root_path,
             info_prefix=args.extra_tag,
+            num_points=args.num_points,
             out_dir=args.out_dir,
             workers=args.workers)

--- a/tools/data_converter/indoor_converter.py
+++ b/tools/data_converter/indoor_converter.py
@@ -12,8 +12,8 @@ from tools.data_converter.sunrgbd_data_utils import SUNRGBDData
 def create_indoor_info_file(data_path,
                             pkl_prefix='sunrgbd',
                             save_path=None,
-                            use_v1=False,
-                            workers=4):
+                            workers=4,
+                            **kwargs):
     """Create indoor information file.
 
     Get information of the raw data and save it to the pkl file.
@@ -23,8 +23,9 @@ def create_indoor_info_file(data_path,
         pkl_prefix (str, optional): Prefix of the pkl to be saved.
             Default: 'sunrgbd'.
         save_path (str, optional): Path of the pkl to be saved. Default: None.
-        use_v1 (bool, optional): Whether to use v1. Default: False.
         workers (int, optional): Number of threads to be used. Default: 4.
+        kwargs (dict): Additional parameters for dataset-specific Data class.
+            May include `use_v1` for SUN RGB-D and `num_points`.
     """
     assert os.path.exists(data_path)
     assert pkl_prefix in ['sunrgbd', 'scannet', 's3dis'], \
@@ -39,10 +40,18 @@ def create_indoor_info_file(data_path,
         val_filename = os.path.join(save_path, f'{pkl_prefix}_infos_val.pkl')
         if pkl_prefix == 'sunrgbd':
             # SUN RGB-D has a train-val split
+            num_points = kwargs.get('num_points', -1)
+            use_v1 = kwargs.get('use_v1', False)
             train_dataset = SUNRGBDData(
-                root_path=data_path, split='train', use_v1=use_v1)
+                root_path=data_path,
+                split='train',
+                use_v1=use_v1,
+                num_points=num_points)
             val_dataset = SUNRGBDData(
-                root_path=data_path, split='val', use_v1=use_v1)
+                root_path=data_path,
+                split='val',
+                use_v1=use_v1,
+                num_points=num_points)
         else:
             # ScanNet has a train-val-test split
             train_dataset = ScanNetData(root_path=data_path, split='train')
@@ -73,18 +82,19 @@ def create_indoor_info_file(data_path,
     if pkl_prefix == 'scannet':
         # label weight computation function is adopted from
         # https://github.com/charlesq34/pointnet2/blob/master/scannet/scannet_dataset.py#L24
+        num_points = kwargs.get('num_points', 8192)
         train_dataset = ScanNetSegData(
             data_root=data_path,
             ann_file=train_filename,
             split='train',
-            num_points=8192,
+            num_points=num_points,
             label_weight_func=lambda x: 1.0 / np.log(1.2 + x))
         # TODO: do we need to generate on val set?
         val_dataset = ScanNetSegData(
             data_root=data_path,
             ann_file=val_filename,
             split='val',
-            num_points=8192,
+            num_points=num_points,
             label_weight_func=lambda x: 1.0 / np.log(1.2 + x))
         # no need to generate for test set
         train_dataset.get_seg_infos()
@@ -101,10 +111,11 @@ def create_indoor_info_file(data_path,
                                     f'{pkl_prefix}_infos_{split}.pkl')
             mmcv.dump(info, filename, 'pkl')
             print(f'{pkl_prefix} info {split} file is saved to {filename}')
+            num_points = kwargs.get('num_points', 4096)
             seg_dataset = S3DISSegData(
                 data_root=data_path,
                 ann_file=filename,
                 split=split,
-                num_points=4096,
+                num_points=num_points,
                 label_weight_func=lambda x: 1.0 / np.log(1.2 + x))
             seg_dataset.get_seg_infos()


### PR DESCRIPTION
## Motivation
Voxel-based methods use more then 50000 points and are able to use unlimited amount of points. So we skip point sampling during preprocessing and keep the possibility for users to sample any amount with `PointSample` further.

## Modification
Add `num_points` to SUN RGB-D preprocessing script.

## BC-breaking (Optional)
Users may update there `*.pkl` files, however the metrics of all models will be the same. The minimal changes may be due to randomness in sampling.
