### PR TITLE
[Fix] missing objects in S3DIS preprocessing

### DIFF
--- a/docs/en/compatibility.md
+++ b/docs/en/compatibility.md
@@ -6,6 +6,10 @@ Before mmdet3d version 1.0.0rc4 we sampled 50000 points following VoteNet prepro
 
 Please refer to the SUN RGB-D [README.md](https://github.com/open-mmlab/mmdetection3d/blob/master/data/sunrgbd/README.md/) for more details.
 
+### Fix a small amount of missing objects during S3DIS preprocessing
+
+We fixed a bug in `tools/data_converter/s3dis_data_utils.py` leading to miss not more than one object per scene. Users need to regenerate the annotations with `tools/create_data.py`.
+
 ## v1.0.0rc1
 
 ### Operators Migration

--- a/tools/data_converter/s3dis_data_utils.py
+++ b/tools/data_converter/s3dis_data_utils.py
@@ -129,7 +129,7 @@ class S3DISData(object):
                 - gt_num (int): Number of boxes.
         """
         bboxes, labels = [], []
-        for i in range(1, pts_instance_mask.max()):
+        for i in range(1, pts_instance_mask.max() + 1):
             ids = pts_instance_mask == i
             # check if all instance points have same semantic label
             assert pts_semantic_mask[ids].min() == pts_semantic_mask[ids].max()


### PR DESCRIPTION
## Motivation

Very few objects (not more than one per scene) are missed due to a bug in S3DIS preprocessing.

## Modification

Just add `+ 1` to fix a bug.

## BC-breaking (Optional)

The users need to regenerate S3DIS annotations. However we do not have 3d object detection models on S3DIS for now.
