### PR TITLE
[Fix] Remove MinkowskiEngine ImportError warnings

### DIFF
--- a/mmdet3d/datasets/pipelines/test_time_aug.py
+++ b/mmdet3d/datasets/pipelines/test_time_aug.py
@@ -138,6 +138,7 @@ class MultiScaleFlipAug3D(object):
             augmentation to point cloud. Defaults to True.
             Note that it works only when 'flip' is turned on.
     """
+
     def __init__(self,
                  transforms,
                  img_scale,

--- a/mmdet3d/datasets/pipelines/test_time_aug.py
+++ b/mmdet3d/datasets/pipelines/test_time_aug.py
@@ -45,7 +45,6 @@ class MultiScaleFlipAug:
             applied. It has no effect when flip == False. Default:
             "horizontal".
     """
-
     def __init__(self,
                  transforms,
                  img_scale=None,
@@ -138,7 +137,6 @@ class MultiScaleFlipAug3D(object):
             augmentation to point cloud. Defaults to True.
             Note that it works only when 'flip' is turned on.
     """
-
     def __init__(self,
                  transforms,
                  img_scale,
@@ -151,7 +149,7 @@ class MultiScaleFlipAug3D(object):
         self.img_scale = img_scale if isinstance(img_scale,
                                                  list) else [img_scale]
         self.pts_scale_ratio = pts_scale_ratio \
-            if isinstance(pts_scale_ratio, list) else[float(pts_scale_ratio)]
+            if isinstance(pts_scale_ratio, list) else [float(pts_scale_ratio)]
 
         assert mmcv.is_list_of(self.img_scale, tuple)
         assert mmcv.is_list_of(self.pts_scale_ratio, float)

--- a/mmdet3d/datasets/pipelines/test_time_aug.py
+++ b/mmdet3d/datasets/pipelines/test_time_aug.py
@@ -45,6 +45,7 @@ class MultiScaleFlipAug:
             applied. It has no effect when flip == False. Default:
             "horizontal".
     """
+
     def __init__(self,
                  transforms,
                  img_scale=None,

--- a/mmdet3d/models/backbones/mink_resnet.py
+++ b/mmdet3d/models/backbones/mink_resnet.py
@@ -5,9 +5,7 @@ try:
     import MinkowskiEngine as ME
     from MinkowskiEngine.modules.resnet_block import BasicBlock, Bottleneck
 except ImportError:
-    import warnings
-    warnings.warn(
-        'Please follow `getting_started.md` to install MinkowskiEngine.`')
+    # Please follow getting_started.md to install MinkowskiEngine.
     # blocks are used in the static part of MinkResNet
     BasicBlock, Bottleneck = None, None
 

--- a/mmdet3d/models/dense_heads/fcaf3d_head.py
+++ b/mmdet3d/models/dense_heads/fcaf3d_head.py
@@ -3,9 +3,8 @@
 try:
     import MinkowskiEngine as ME
 except ImportError:
-    import warnings
-    warnings.warn(
-        'Please follow `getting_started.md` to install MinkowskiEngine.`')
+    # Please follow getting_started.md to install MinkowskiEngine.
+    pass
 
 import torch
 from mmcv.cnn import Scale, bias_init_with_prob

--- a/mmdet3d/models/detectors/dynamic_voxelnet.py
+++ b/mmdet3d/models/detectors/dynamic_voxelnet.py
@@ -24,16 +24,17 @@ class DynamicVoxelNet(VoxelNet):
                  test_cfg=None,
                  pretrained=None,
                  init_cfg=None):
-        super(DynamicVoxelNet, self).__init__(voxel_layer=voxel_layer,
-                                              voxel_encoder=voxel_encoder,
-                                              middle_encoder=middle_encoder,
-                                              backbone=backbone,
-                                              neck=neck,
-                                              bbox_head=bbox_head,
-                                              train_cfg=train_cfg,
-                                              test_cfg=test_cfg,
-                                              pretrained=pretrained,
-                                              init_cfg=init_cfg)
+        super(DynamicVoxelNet, self).__init__(
+            voxel_layer=voxel_layer,
+            voxel_encoder=voxel_encoder,
+            middle_encoder=middle_encoder,
+            backbone=backbone,
+            neck=neck,
+            bbox_head=bbox_head,
+            train_cfg=train_cfg,
+            test_cfg=test_cfg,
+            pretrained=pretrained,
+            init_cfg=init_cfg)
 
     def extract_feat(self, points, img_metas):
         """Extract features from points."""

--- a/mmdet3d/models/detectors/dynamic_voxelnet.py
+++ b/mmdet3d/models/detectors/dynamic_voxelnet.py
@@ -9,9 +9,9 @@ from .voxelnet import VoxelNet
 
 @DETECTORS.register_module()
 class DynamicVoxelNet(VoxelNet):
-    r"""VoxelNet using `dynamic voxelization <https://arxiv.org/abs/1910.06528>`_.
+    r"""VoxelNet using `dynamic voxelization
+        <https://arxiv.org/abs/1910.06528>`_.
     """
-
     def __init__(self,
                  voxel_layer,
                  voxel_encoder,
@@ -23,17 +23,16 @@ class DynamicVoxelNet(VoxelNet):
                  test_cfg=None,
                  pretrained=None,
                  init_cfg=None):
-        super(DynamicVoxelNet, self).__init__(
-            voxel_layer=voxel_layer,
-            voxel_encoder=voxel_encoder,
-            middle_encoder=middle_encoder,
-            backbone=backbone,
-            neck=neck,
-            bbox_head=bbox_head,
-            train_cfg=train_cfg,
-            test_cfg=test_cfg,
-            pretrained=pretrained,
-            init_cfg=init_cfg)
+        super(DynamicVoxelNet, self).__init__(voxel_layer=voxel_layer,
+                                              voxel_encoder=voxel_encoder,
+                                              middle_encoder=middle_encoder,
+                                              backbone=backbone,
+                                              neck=neck,
+                                              bbox_head=bbox_head,
+                                              train_cfg=train_cfg,
+                                              test_cfg=test_cfg,
+                                              pretrained=pretrained,
+                                              init_cfg=init_cfg)
 
     def extract_feat(self, points, img_metas):
         """Extract features from points."""

--- a/mmdet3d/models/detectors/dynamic_voxelnet.py
+++ b/mmdet3d/models/detectors/dynamic_voxelnet.py
@@ -12,6 +12,7 @@ class DynamicVoxelNet(VoxelNet):
     r"""VoxelNet using `dynamic voxelization
         <https://arxiv.org/abs/1910.06528>`_.
     """
+
     def __init__(self,
                  voxel_layer,
                  voxel_encoder,

--- a/mmdet3d/models/detectors/mink_single_stage.py
+++ b/mmdet3d/models/detectors/mink_single_stage.py
@@ -3,9 +3,8 @@
 try:
     import MinkowskiEngine as ME
 except ImportError:
-    import warnings
-    warnings.warn(
-        'Please follow `getting_started.md` to install MinkowskiEngine.`')
+    # Please follow getting_started.md to install MinkowskiEngine.
+    pass
 
 from mmdet3d.core import bbox3d2result
 from mmdet3d.models import DETECTORS, build_backbone, build_head


### PR DESCRIPTION
## Motivation

MinkowskiEngine is an extra requirement. We do not want to spam not using MinkowskiEngine users with warnings from all python files where it is imported (on every run of mmdetection3d).

## Modification

Just remove warning when MinkowskiEngine is not installed.

## BC-breaking (Optional)

No.

