### PR TITLE
new update in dev branch:Fix waymo converter to save img in .jpg(offical in waymo open) reduce dataset from 3.3T to 1.1T

### DIFF
--- a/tools/data_converter/kitti_data_utils.py
+++ b/tools/data_converter/kitti_data_utils.py
@@ -46,8 +46,9 @@ def get_image_path(idx,
                    relative_path=True,
                    exist_check=True,
                    info_type='image_2',
+                   file_tail='.png',
                    use_prefix_id=False):
-    return get_kitti_info_path(idx, prefix, info_type, '.png', training,
+    return get_kitti_info_path(idx, prefix, info_type, file_tail, training,
                                relative_path, exist_check, use_prefix_id)
 
 
@@ -378,6 +379,7 @@ class WaymoInfoGatherer:
             self.training,
             self.relative_path,
             info_type='image_0',
+            file_tail='.jpg',
             use_prefix_id=True)
         if self.with_imageshape:
             img_path = image_info['image_path']

--- a/tools/data_converter/waymo_converter.py
+++ b/tools/data_converter/waymo_converter.py
@@ -130,7 +130,9 @@ class Waymo2KITTI(object):
         return len(self.tfrecord_pathnames)
 
     def save_image(self, frame, file_idx, frame_idx):
-        """Parse and save the images in png format.
+        """Parse and save the images in jpg format. Jpg is the original format
+        used by Waymo Open dataset. Saving in png format will cause huge (~3x)
+        unnesssary storage waste.
 
         Args:
             frame (:obj:`Frame`): Open dataset frame proto.
@@ -140,9 +142,9 @@ class Waymo2KITTI(object):
         for img in frame.images:
             img_path = f'{self.image_save_dir}{str(img.name - 1)}/' + \
                 f'{self.prefix}{str(file_idx).zfill(3)}' + \
-                f'{str(frame_idx).zfill(3)}.png'
-            img = mmcv.imfrombytes(img.image)
-            mmcv.imwrite(img, img_path)
+                f'{str(frame_idx).zfill(3)}.jpg'
+            with open(img_path, 'wb') as fp:
+                fp.write(img.image)
 
     def save_calib(self, frame, file_idx, frame_idx):
         """Parse and save the calibration data.


### PR DESCRIPTION
## Motivation

This PR follows the PR in https://github.com/open-mmlab/mmdetection3d/pull/1690
Just change branch to `dev`

## Modification

I modifed the `save_image` function in class `Waymo2KITTI`
in `tools/data_converter/waymo_converter.py`

To make the generated  \*\*\*.pkl to remember the image's file_tail is `.jpg`. I modified the `get_image_path` function in `tools/data_converter/kitti_data_utils.py`, add a file_tail(default='.png') param for it to make the `.jpg` file_tail be able to be passed in. Besides, this willnot disturb the usage for KITTI processing.
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
