### PR TITLE
feat(inference.py): add default value for output dir

### DIFF
--- a/mmdet3d/apis/inference.py
+++ b/mmdet3d/apis/inference.py
@@ -483,7 +483,7 @@ def show_proj_det_result_meshlab(data,
 
 def show_result_meshlab(data,
                         result,
-                        out_dir,
+                        out_dir='mmdet3d-output',
                         score_thr=0.0,
                         show=False,
                         snapshot=False,
@@ -494,7 +494,7 @@ def show_result_meshlab(data,
     Args:
         data (dict): Contain data from pipeline.
         result (dict): Predicted result from model.
-        out_dir (str): Directory to save visualized result.
+        out_dir (str): Directory to save visualized result, Default: mmdet3d-output
         score_thr (float, optional): Minimum score of bboxes to be shown.
             Default: 0.0
         show (bool, optional): Visualize the results online. Defaults to False.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

mmdeploy 集成 mmdet3d 渲染结果的时候，会因为 output dir  is None ， assert 崩溃。

其他算法 repo 有类似 output-file 变量，然而 mmdet3d 要的是 output-dir .... 感觉混用也不太对。

所以希望 mmdet3d 有个默认的 output-dir 


## Modification

default.py  output-dir support default value.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
