### PR TITLE
[Fix] Fix image saving in the waymo preprocessing script.

### DIFF
--- a/tools/dataset_converters/waymo_converter.py
+++ b/tools/dataset_converters/waymo_converter.py
@@ -12,7 +12,6 @@ except ImportError:
 from glob import glob
 from os.path import join
 
-import mmcv
 import mmengine
 import numpy as np
 import tensorflow as tf
@@ -162,8 +161,8 @@ class Waymo2KITTI(object):
             img_path = f'{self.image_save_dir}{str(img.name - 1)}/' + \
                 f'{self.prefix}{str(file_idx).zfill(3)}' + \
                 f'{str(frame_idx).zfill(3)}.jpg'
-            img = mmcv.imfrombytes(img.image)
-            mmcv.imwrite(img, img_path)
+            with open(img_path, 'wb') as fp:
+                fp.write(img.image)
 
     def save_calib(self, frame, file_idx, frame_idx):
         """Parse and save the calibration data.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The image writing using mmcv is through decoding and encoding, then saving as a .'jpg' image. It will lose some image information.

Our original solution: decoding and encoding the image info, and then saving it as a .'png' image. It will not lose image info but cause a large storage footprint since the '.png' encoding.

New Solution: writing the image as a file in 'wb' mode like this [PR](https://github.com/open-mmlab/mmdetection3d/blob/dev/tools/data_converter/waymo_converter.py#L146), which is merged in the dev branch.

The above observation has been verified on a toy image.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
