### PR TITLE
[Fix] Fix stuck in `torch.einsum` when create dataset

### DIFF
--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -256,7 +256,8 @@ args = parser.parse_args()
 if __name__ == '__main__':
     from mmdet3d.utils import register_all_modules
     register_all_modules()
-
+    
+    # Set to spawn mode to avoid stuck when process dataset creating
     import multiprocessing
     multiprocessing.set_start_method('spawn')
 

--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -257,8 +257,8 @@ if __name__ == '__main__':
     from mmdet3d.utils import register_all_modules
     register_all_modules()
 
-    import multiprocessing as mp
-    mp.set_start_method("spawn")
+    import multiprocessing
+    multiprocessing.set_start_method("spawn")
 
     if args.dataset == 'kitti':
         kitti_data_prep(

--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -258,7 +258,7 @@ if __name__ == '__main__':
     register_all_modules()
 
     import multiprocessing
-    multiprocessing.set_start_method("spawn")
+    multiprocessing.set_start_method('spawn')
 
     if args.dataset == 'kitti':
         kitti_data_prep(

--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -256,7 +256,7 @@ args = parser.parse_args()
 if __name__ == '__main__':
     from mmdet3d.utils import register_all_modules
     register_all_modules()
-    
+
     # Set to spawn mode to avoid stuck when process dataset creating
     import multiprocessing
     multiprocessing.set_start_method('spawn')

--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -256,6 +256,10 @@ args = parser.parse_args()
 if __name__ == '__main__':
     from mmdet3d.utils import register_all_modules
     register_all_modules()
+
+    import multiprocessing as mp
+    mp.set_start_method("spawn")
+
     if args.dataset == 'kitti':
         kitti_data_prep(
             root_path=args.root_path,


### PR DESCRIPTION
## Motivation

When process `create_dataset.py` for waymo, will stuck in `torch.einsum`

![image](https://user-images.githubusercontent.com/25873202/204472066-f7fc5fa1-ebb7-4101-8403-bf74e2f5099e.png)

![image](https://user-images.githubusercontent.com/25873202/204473836-0a11b936-35d5-4d01-bec2-567eed5b17bb.png)


## Modification

Add `multiprocessing.set_start_method("spawn")` setting at the beginning of the code. 

After added this code, will process successful.

![image](https://user-images.githubusercontent.com/25873202/204473048-a7ae14df-5b00-42c7-836c-4149166dc93b.png)

## Env 

```shell
sys.platform: linux
Python: 3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:49:35) [GCC 10.4.0]
CUDA available: True
numpy_random_seed: 2147483648
GPU 0: NVIDIA GeForce RTX 3080 Ti
CUDA_HOME: /usr/local/cuda
NVCC: Cuda compilation tools, release 11.5, V11.5.119
GCC: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
PyTorch: 1.12.0
PyTorch compiling details: PyTorch built with:
  - GCC 9.3
  - C++ Version: 201402
  - Intel(R) oneAPI Math Kernel Library Version 2021.4-Product Build 20210904 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v2.6.0 (Git Hash 52b5f107dd9cf10910aaa19cb47f3abf9b349815)
  - OpenMP 201511 (a.k.a. OpenMP 4.5)
  - LAPACK is enabled (usually provided by MKL)
  - NNPACK is enabled
  - CPU capability usage: AVX2
  - CUDA Runtime 11.3
  - NVCC architecture flags: -gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_61,code=sm_61;-gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_37,code=compute_37
  - CuDNN 8.3.2  (built against CUDA 11.5)
  - Magma 2.5.2
  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, CUDA_VERSION=11.3, CUDNN_VERSION=8.3.2, CXX_COMPILER=/opt/rh/devtoolset-9/root/usr/bin/c++, CXX_FLAGS= -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp -DNDEBUG -DUSE_KINETO -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -DEDGE_PROFILER_USE_KINETO -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror=return-type -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-function -Wno-unused-result -Wno-unused-local-typedefs -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-stringop-overflow -Wno-psabi -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-unused-but-set-variable -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Werror=cast-function-type -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, PERF_WITH_AVX512=1, TORCH_VERSION=1.12.0, USE_CUDA=ON, USE_CUDNN=ON, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=OFF, USE_MPI=OFF, USE_NCCL=ON, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, 

TorchVision: 0.13.0
OpenCV: 4.6.0
MMEngine: 0.3.2
MMDetection: 3.0.0rc3
MMDetection3D: 1.1.0rc1+8c0541b
spconv2.0: False
```