### PR TITLE
[Fix] lidar2cam error in update_infos_to_v2.py for nus and lyft dataset.

### DIFF
--- a/tools/dataset_converters/update_infos_to_v2.py
+++ b/tools/dataset_converters/update_infos_to_v2.py
@@ -302,8 +302,10 @@ def update_nuscenes_infos(pkl_path, out_dir):
                 ori_sweep['ego2global_rotation'],
                 ori_sweep['ego2global_translation'])
             lidar2sensor = np.eye(4)
-            lidar2sensor[:3, :3] = ori_sweep['sensor2lidar_rotation'].T
-            lidar2sensor[:3, 3] = -ori_sweep['sensor2lidar_translation']
+            rot = ori_sweep['sensor2lidar_rotation']
+            trans = ori_sweep['sensor2lidar_translation']
+            lidar2sensor[:3, :3] = rot.T
+            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             temp_lidar_sweep['lidar_points'][
                 'lidar2sensor'] = lidar2sensor.astype(np.float32).tolist()
             temp_lidar_sweep['timestamp'] = ori_sweep['timestamp'] / 1e6
@@ -781,8 +783,10 @@ def update_lyft_infos(pkl_path, out_dir):
                 ori_sweep['ego2global_rotation'],
                 ori_sweep['ego2global_translation'])
             lidar2sensor = np.eye(4)
-            lidar2sensor[:3, :3] = ori_sweep['sensor2lidar_rotation'].T
-            lidar2sensor[:3, 3] = -ori_sweep['sensor2lidar_translation']
+            rot = ori_sweep['sensor2lidar_rotation']
+            trans = ori_sweep['sensor2lidar_translation']
+            lidar2sensor[:3, :3] = rot.T
+            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             temp_lidar_sweep['lidar_points'][
                 'lidar2sensor'] = lidar2sensor.astype(np.float32).tolist()
             # bc-breaking: Timestamp has divided 1e6 in pkl infos.

--- a/tools/dataset_converters/update_infos_to_v2.py
+++ b/tools/dataset_converters/update_infos_to_v2.py
@@ -328,10 +328,10 @@ def update_nuscenes_infos(pkl_path, out_dir):
                 ori_info_dict['cams'][cam]['sensor2ego_rotation'],
                 ori_info_dict['cams'][cam]['sensor2ego_translation'])
             lidar2sensor = np.eye(4)
-            lidar2sensor[:3, :3] = ori_info_dict['cams'][cam][
-                'sensor2lidar_rotation'].T
-            lidar2sensor[:3, 3] = -ori_info_dict['cams'][cam][
-                'sensor2lidar_translation']
+            rot = ori_info_dict['cams'][cam]['sensor2lidar_rotation']
+            trans = ori_info_dict['cams'][cam]['sensor2lidar_translation']
+            lidar2sensor[:3, :3] = rot.T
+            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             empty_img_info['lidar2cam'] = lidar2sensor.astype(
                 np.float32).tolist()
             temp_data_info['images'][cam] = empty_img_info
@@ -807,10 +807,10 @@ def update_lyft_infos(pkl_path, out_dir):
                 ori_info_dict['cams'][cam]['sensor2ego_rotation'],
                 ori_info_dict['cams'][cam]['sensor2ego_translation'])
             lidar2sensor = np.eye(4)
-            lidar2sensor[:3, :3] = ori_info_dict['cams'][cam][
-                'sensor2lidar_rotation'].T
-            lidar2sensor[:3, 3] = -ori_info_dict['cams'][cam][
-                'sensor2lidar_translation']
+            rot = ori_info_dict['cams'][cam]['sensor2lidar_rotation']
+            trans = ori_info_dict['cams'][cam]['sensor2lidar_translation']
+            lidar2sensor[:3, :3] = rot.T
+            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             empty_img_info['lidar2cam'] = lidar2sensor.astype(
                 np.float32).tolist()
             temp_data_info['images'][cam] = empty_img_info


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

lidar2cam error in update_infos_to_v2.py for nus and lyft dataset.

In the latest info version, we save the transformation from lidar to camera coordinate system with a unified transformation matrix, but the original implementation does not multiply the rotation matrix with the translation matrix, leading to errors in transformation matrices. This PR fixes this problem, and users should re-convert info with the new script.

This problem does not affect the currently supported models in 1.x but may yield potential errors for BEV-series detectors.

## Modification

change the translation from -t to -R^{-1}t


