### PR TITLE
[Fix] Fix numpy ValueError in update_infos_to_v2.py

### DIFF
--- a/tools/dataset_converters/update_infos_to_v2.py
+++ b/tools/dataset_converters/update_infos_to_v2.py
@@ -305,7 +305,7 @@ def update_nuscenes_infos(pkl_path, out_dir):
             rot = ori_sweep['sensor2lidar_rotation']
             trans = ori_sweep['sensor2lidar_translation']
             lidar2sensor[:3, :3] = rot.T
-            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
+            lidar2sensor[:3, 3:4] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             temp_lidar_sweep['lidar_points'][
                 'lidar2sensor'] = lidar2sensor.astype(np.float32).tolist()
             temp_lidar_sweep['timestamp'] = ori_sweep['timestamp'] / 1e6
@@ -333,7 +333,7 @@ def update_nuscenes_infos(pkl_path, out_dir):
             rot = ori_info_dict['cams'][cam]['sensor2lidar_rotation']
             trans = ori_info_dict['cams'][cam]['sensor2lidar_translation']
             lidar2sensor[:3, :3] = rot.T
-            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
+            lidar2sensor[:3, 3:4] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             empty_img_info['lidar2cam'] = lidar2sensor.astype(
                 np.float32).tolist()
             temp_data_info['images'][cam] = empty_img_info
@@ -786,7 +786,7 @@ def update_lyft_infos(pkl_path, out_dir):
             rot = ori_sweep['sensor2lidar_rotation']
             trans = ori_sweep['sensor2lidar_translation']
             lidar2sensor[:3, :3] = rot.T
-            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
+            lidar2sensor[:3, 3:4] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             temp_lidar_sweep['lidar_points'][
                 'lidar2sensor'] = lidar2sensor.astype(np.float32).tolist()
             # bc-breaking: Timestamp has divided 1e6 in pkl infos.
@@ -814,7 +814,7 @@ def update_lyft_infos(pkl_path, out_dir):
             rot = ori_info_dict['cams'][cam]['sensor2lidar_rotation']
             trans = ori_info_dict['cams'][cam]['sensor2lidar_translation']
             lidar2sensor[:3, :3] = rot.T
-            lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
+            lidar2sensor[:3, 3:4] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
             empty_img_info['lidar2cam'] = lidar2sensor.astype(
                 np.float32).tolist()
             temp_data_info['images'][cam] = empty_img_info


### PR DESCRIPTION
## Motivation

Fix numpy value assignment error. I was updating an info.pkl generated from an older mmdet3d of v1.0.0rc2, via command
` python tools/dataset_converters/update_infos_to_v2.py --dataset nuscenes --pkl-path ./data/nus_rc2/nuscenes_infos_val.pkl --out-dir ./data/nus_v2`
I encountered this error:
`File "tools/dataset_converters/update_infos_to_v2.py", line 336, in update_nuscenes_infos
    lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))`
`ValueError: could not broadcast input array from shape (3,1) into shape (3,)`


## Modification
In update_infos_to_v2.py, I simply changed all `lidar2sensor[:3, 3] = -1 * np.matmul(rot.T, trans.reshape(3, 1))` to `lidar2sensor[:3, 3:4] = -1 * np.matmul(rot.T, trans.reshape(3, 1))`