### PR TITLE
[Feature] Support MLU backend on the dev branch

### DIFF
--- a/mmdet3d/apis/train.py
+++ b/mmdet3d/apis/train.py
@@ -5,7 +5,6 @@ import warnings
 
 import numpy as np
 import torch
-from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (HOOKS, DistSamplerSeedHook, EpochBasedRunner,
                          Fp16OptimizerHook, OptimizerHook, build_optimizer,
                          build_runner, get_dist_info)
@@ -13,7 +12,7 @@ from mmcv.utils import build_from_cfg
 from torch import distributed as dist
 
 from mmdet3d.datasets import build_dataset
-from mmdet3d.utils import find_latest_checkpoint, build_ddp, build_dp
+from mmdet3d.utils import build_ddp, build_dp, find_latest_checkpoint
 from mmdet.core import DistEvalHook as MMDET_DistEvalHook
 from mmdet.core import EvalHook as MMDET_EvalHook
 from mmdet.datasets import build_dataloader as build_mmdet_dataloader
@@ -104,10 +103,12 @@ def train_segmentor(model,
         find_unused_parameters = cfg.get('find_unused_parameters', False)
         # Sets the `find_unused_parameters` parameter in
         # torch.nn.parallel.DistributedDataParallel
-        model = build_ddp(model, cfg.device,
-                          device_ids=[int(os.environ['LOCAL_RANK'])],
-                          broadcast_buffers=False,
-                          find_unused_parameters=find_unused_parameters)
+        model = build_ddp(
+            model,
+            cfg.device,
+            device_ids=[int(os.environ['LOCAL_RANK'])],
+            broadcast_buffers=False,
+            find_unused_parameters=find_unused_parameters)
     else:
         model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
 
@@ -222,10 +223,12 @@ def train_detector(model,
         find_unused_parameters = cfg.get('find_unused_parameters', False)
         # Sets the `find_unused_parameters` parameter in
         # torch.nn.parallel.DistributedDataParallel
-        model = build_ddp(model, cfg.device,
-                          device_ids=[int(os.environ['LOCAL_RANK'])],
-                          broadcast_buffers=False,
-                          find_unused_parameters=find_unused_parameters)
+        model = build_ddp(
+            model,
+            cfg.device,
+            device_ids=[int(os.environ['LOCAL_RANK'])],
+            broadcast_buffers=False,
+            find_unused_parameters=find_unused_parameters)
     else:
         model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
 

--- a/mmdet3d/apis/train.py
+++ b/mmdet3d/apis/train.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os
 import random
 import warnings
 
@@ -12,7 +13,7 @@ from mmcv.utils import build_from_cfg
 from torch import distributed as dist
 
 from mmdet3d.datasets import build_dataset
-from mmdet3d.utils import find_latest_checkpoint
+from mmdet3d.utils import find_latest_checkpoint, build_ddp, build_dp
 from mmdet.core import DistEvalHook as MMDET_DistEvalHook
 from mmdet.core import EvalHook as MMDET_EvalHook
 from mmdet.datasets import build_dataloader as build_mmdet_dataloader
@@ -103,14 +104,12 @@ def train_segmentor(model,
         find_unused_parameters = cfg.get('find_unused_parameters', False)
         # Sets the `find_unused_parameters` parameter in
         # torch.nn.parallel.DistributedDataParallel
-        model = MMDistributedDataParallel(
-            model.cuda(),
-            device_ids=[torch.cuda.current_device()],
-            broadcast_buffers=False,
-            find_unused_parameters=find_unused_parameters)
+        model = build_ddp(model, cfg.device,
+                          device_ids=[int(os.environ['LOCAL_RANK'])],
+                          broadcast_buffers=False,
+                          find_unused_parameters=find_unused_parameters)
     else:
-        model = MMDataParallel(
-            model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
+        model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)
@@ -223,14 +222,12 @@ def train_detector(model,
         find_unused_parameters = cfg.get('find_unused_parameters', False)
         # Sets the `find_unused_parameters` parameter in
         # torch.nn.parallel.DistributedDataParallel
-        model = MMDistributedDataParallel(
-            model.cuda(),
-            device_ids=[torch.cuda.current_device()],
-            broadcast_buffers=False,
-            find_unused_parameters=find_unused_parameters)
+        model = build_ddp(model, cfg.device,
+                          device_ids=[int(os.environ['LOCAL_RANK'])],
+                          broadcast_buffers=False,
+                          find_unused_parameters=find_unused_parameters)
     else:
-        model = MMDataParallel(
-            model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
+        model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)

--- a/mmdet3d/utils/__init__.py
+++ b/mmdet3d/utils/__init__.py
@@ -6,9 +6,10 @@ from .compat_cfg import compat_cfg
 from .logger import get_root_logger
 from .misc import find_latest_checkpoint
 from .setup_env import setup_multi_processes
+from .util_distribution import build_dp, build_ddp, get_device
 
 __all__ = [
     'Registry', 'build_from_cfg', 'get_root_logger', 'collect_env',
     'print_log', 'setup_multi_processes', 'find_latest_checkpoint',
-    'compat_cfg'
+    'compat_cfg', 'build_ddp', 'build_dp', 'get_device'
 ]

--- a/mmdet3d/utils/__init__.py
+++ b/mmdet3d/utils/__init__.py
@@ -6,7 +6,7 @@ from .compat_cfg import compat_cfg
 from .logger import get_root_logger
 from .misc import find_latest_checkpoint
 from .setup_env import setup_multi_processes
-from .util_distribution import build_dp, build_ddp, get_device
+from .util_distribution import build_ddp, build_dp, get_device
 
 __all__ = [
     'Registry', 'build_from_cfg', 'get_root_logger', 'collect_env',

--- a/mmdet3d/utils/util_distribution.py
+++ b/mmdet3d/utils/util_distribution.py
@@ -1,0 +1,67 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
+
+dp_factory = {'cuda': MMDataParallel, 'cpu': MMDataParallel}
+
+ddp_factory = {'cuda': MMDistributedDataParallel}
+
+
+def build_dp(model, device='cuda', dim=0, *args, **kwargs):
+    """build DataParallel module by device type.
+    if device is cuda, return a MMDataParallel model; if device is mlu,
+    return a MLUDataParallel model.
+    Args:
+        model (:class:`nn.Module`): model to be parallelized.
+        device (str): device type, cuda, cpu or mlu. Defaults to cuda.
+        dim (int): Dimension used to scatter the data. Defaults to 0.
+    Returns:
+        nn.Module: the model to be parallelized.
+    """
+    if device == 'cuda':
+        model = model.cuda(kwargs['device_ids'][0])
+    elif device == 'mlu':
+        from mmcv.device.mlu import MLUDataParallel
+        dp_factory['mlu'] = MLUDataParallel
+        model = model.mlu()
+
+    return dp_factory[device](model, dim=dim, *args, **kwargs)
+
+
+def build_ddp(model, device='cuda', *args, **kwargs):
+    """Build DistributedDataParallel module by device type.
+    If device is cuda, return a MMDistributedDataParallel model;
+    if device is mlu, return a MLUDistributedDataParallel model.
+    Args:
+        model (:class:`nn.Module`): module to be parallelized.
+        device (str): device type, mlu or cuda.
+    Returns:
+        :class:`nn.Module`: the module to be parallelized
+    References:
+        .. [1] https://pytorch.org/docs/stable/generated/torch.nn.parallel.
+                     DistributedDataParallel.html
+    """
+    assert device in ['cuda', 'mlu'], 'Only available for cuda or mlu devices.'
+    if device == 'cuda':
+        model = model.cuda()
+    elif device == 'mlu':
+        from mmcv.device.mlu import MLUDistributedDataParallel
+        ddp_factory['mlu'] = MLUDistributedDataParallel
+        model = model.mlu()
+
+    return ddp_factory[device](model, *args, **kwargs)
+
+
+def is_mlu_available():
+    """Returns a bool indicating if MLU is currently available."""
+    return hasattr(torch, 'is_mlu_available') and torch.is_mlu_available()
+
+
+def get_device():
+    """Returns an available device, cpu, cuda or mlu."""
+    is_device_available = {
+        'cuda': torch.cuda.is_available(),
+        'mlu': is_mlu_available()
+    }
+    device_list = [k for k, v in is_device_available.items() if v]
+    return device_list[0] if len(device_list) >= 1 else 'cpu'

--- a/tools/test.py
+++ b/tools/test.py
@@ -7,12 +7,12 @@ import mmcv
 import torch
 from mmcv import Config, DictAction
 from mmcv.cnn import fuse_conv_bn
-from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
                          wrap_fp16_model)
 
 import mmdet
 from mmdet3d.apis import single_gpu_test
+from mmdet3d.utils import build_ddp, build_dp, get_device
 from mmdet3d.datasets import build_dataloader, build_dataset
 from mmdet3d.models import build_model
 from mmdet.apis import multi_gpu_test, set_random_seed
@@ -165,7 +165,7 @@ def main():
                       'in `gpu_ids` now.')
     else:
         cfg.gpu_ids = [args.gpu_id]
-
+    cfg.device = get_device()
     # init distributed env first, since logger depends on the dist info.
     if args.launcher == 'none':
         distributed = False
@@ -226,13 +226,12 @@ def main():
         model.PALETTE = dataset.PALETTE
 
     if not distributed:
-        model = MMDataParallel(model, device_ids=cfg.gpu_ids)
+        model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
         outputs = single_gpu_test(model, data_loader, args.show, args.show_dir)
     else:
-        model = MMDistributedDataParallel(
-            model.cuda(),
-            device_ids=[torch.cuda.current_device()],
-            broadcast_buffers=False)
+        model = build_ddp(model, cfg.device,
+￼                          device_ids=[int(os.environ['LOCAL_RANK'])],
+￼                          broadcast_buffers=False)
         outputs = multi_gpu_test(model, data_loader, args.tmpdir,
                                  args.gpu_collect)
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -12,9 +12,9 @@ from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
 
 import mmdet
 from mmdet3d.apis import single_gpu_test
-from mmdet3d.utils import build_ddp, build_dp, get_device
 from mmdet3d.datasets import build_dataloader, build_dataset
 from mmdet3d.models import build_model
+from mmdet3d.utils import build_ddp, build_dp, get_device
 from mmdet.apis import multi_gpu_test, set_random_seed
 from mmdet.datasets import replace_ImageToTensor
 
@@ -229,9 +229,11 @@ def main():
         model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
         outputs = single_gpu_test(model, data_loader, args.show, args.show_dir)
     else:
-        model = build_ddp(model, cfg.device,
-￼                          device_ids=[int(os.environ['LOCAL_RANK'])],
-￼                          broadcast_buffers=False)
+        model = build_ddp(
+            model,
+            cfg.device,
+            device_ids=[int(os.environ['LOCAL_RANK'])],
+            broadcast_buffers=False)
         outputs = multi_gpu_test(model, data_loader, args.tmpdir,
                                  args.gpu_collect)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -18,7 +18,7 @@ from mmdet3d import __version__ as mmdet3d_version
 from mmdet3d.apis import init_random_seed, train_model
 from mmdet3d.datasets import build_dataset
 from mmdet3d.models import build_model
-from mmdet3d.utils import collect_env, get_root_logger
+from mmdet3d.utils import collect_env, get_root_logger, get_device
 from mmdet.apis import set_random_seed
 from mmseg import __version__ as mmseg_version
 
@@ -206,8 +206,9 @@ def main():
     logger.info(f'Distributed training: {distributed}')
     logger.info(f'Config:\n{cfg.pretty_text}')
 
+    cfg.device = get_device()
     # set random seeds
-    seed = init_random_seed(args.seed)
+    seed = init_random_seed(args.seed, device=cfg.device)
     seed = seed + dist.get_rank() if args.diff_seed else seed
     logger.info(f'Set random seed to {seed}, '
                 f'deterministic: {args.deterministic}')

--- a/tools/train.py
+++ b/tools/train.py
@@ -18,7 +18,7 @@ from mmdet3d import __version__ as mmdet3d_version
 from mmdet3d.apis import init_random_seed, train_model
 from mmdet3d.datasets import build_dataset
 from mmdet3d.models import build_model
-from mmdet3d.utils import collect_env, get_root_logger, get_device
+from mmdet3d.utils import collect_env, get_device, get_root_logger
 from mmdet.apis import set_random_seed
 from mmseg import __version__ as mmseg_version
 


### PR DESCRIPTION
Mmdet3d support PyTorch backend on MLU (with Cambricon PyTorch).

Motivation
Support Cambricon MLU device for PyTorch backend.

Modification
mmdet3d/utils/util_distribution.py 、mmdet3d/utils/init.py : add build_ddp, build_dp and get_device functions to use different devices.
mmdet3d/apis/train.py 、 tools/test.py、tools/train.py : use build_ddp, build_dp to support mlu backend.

Checklist
Pre-commit or other linting tools are used to fix the potential lint issues.
The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
The documentation has been modified accordingly, like docstring or example tutorials.