### PR TITLE
More customizable and Faster waymo evaluation

### DIFF
--- a/mmdet3d/evaluation/functional/waymo_utils/prediction_to_waymo.py
+++ b/mmdet3d/evaluation/functional/waymo_utils/prediction_to_waymo.py
@@ -15,7 +15,7 @@ except ImportError:
         'to install the official devkit first.')
 
 from glob import glob
-from os.path import join
+from os.path import exists, join
 from typing import List, Optional
 
 import mmengine
@@ -60,7 +60,8 @@ class Prediction2Waymo(object):
                  workers: int = 2,
                  file_client_args: dict = dict(backend='disk'),
                  from_kitti_format: bool = False,
-                 idx2metainfo: Optional[dict] = None):
+                 idx2metainfo: Optional[dict] = None,
+                 ann_file: str = None):
 
         self.results = results
         self.waymo_tfrecords_dir = waymo_tfrecords_dir
@@ -71,13 +72,6 @@ class Prediction2Waymo(object):
         self.workers = int(workers)
         self.file_client_args = file_client_args
         self.from_kitti_format = from_kitti_format
-        if idx2metainfo is not None:
-            self.idx2metainfo = idx2metainfo
-            # If ``fast_eval``, the metainfo does not need to be read from
-            # original data online. It's preprocessed offline.
-            self.fast_eval = True
-        else:
-            self.fast_eval = False
 
         self.name2idx = {}
 
@@ -103,14 +97,70 @@ class Prediction2Waymo(object):
             for idx, result in enumerate(results):
                 self.name2idx[str(result['sample_idx'])] = idx
 
-        if not self.fast_eval:
-            # need to read original '.tfrecord' file
+        self.create_folder()
+
+        if idx2metainfo is not None:
+            self.idx2metainfo = idx2metainfo
+        else:
             self.get_file_names()
             # turn on eager execution for older tensorflow versions
             if int(tf.__version__.split('.')[0]) < 2:
                 tf.enable_eager_execution()
+            self.info_path = join(self.waymo_tfrecords_dir, 'idx2metainfo.pkl')
+            if not exists(self.info_path):
+                self.ann_file = ann_file
+                print('it is the first time you evaluate this dataset split,\
+                    we will collect info in tfrecords to speed up evaluations')
+                self.gather_tfrecord_info()
+            self.idx2metainfo = mmengine.load(self.info_path)
 
-        self.create_folder()
+    def gather_tfrecord_info(self):
+        """Collect idx2metainfo for fast evaluation. idx2metainfo is a mapping
+        between 'sample_idx' in annotation.
+
+        .pkl files and (contextname, timestamp) in waymo tfrecords file
+        Usage:
+            self.idx2metainfo[str(sample_idx)]['contextname']
+            self.idx2metainfo[str(sample_idx)]['timestamp']
+        """
+        print('extracting info in tfrecords...')
+        prog_bar = mmengine.ProgressBar(len(self.waymo_tfrecord_pathnames))
+        tf_infos = {}
+        for file_idx in range(len(self.waymo_tfrecord_pathnames)):
+            file_pathname = self.waymo_tfrecord_pathnames[file_idx]
+            file_data = tf.data.TFRecordDataset(
+                file_pathname, compression_type='')
+
+            for frame_num, frame_data in enumerate(file_data):
+                frame = open_dataset.Frame()
+                frame.ParseFromString(bytearray(frame_data.numpy()))
+                filename = f'{self.prefix}{file_idx:03d}{frame_num:03d}'
+                context_name = frame.context.name  # file name strip
+                frame_timestamp_micros = frame.timestamp_micros  # timestamp
+
+                info = {
+                    'filename': filename,
+                    'context_name': context_name,
+                    'frame_timestamp_micros': frame_timestamp_micros
+                }
+                tf_infos[frame_timestamp_micros] = info
+            prog_bar.update()
+
+        data_list = mmengine.load(self.ann_file)['data_list']
+        idx2metainfo = {}
+        print('generating idx2metainfo...')
+        prog_bar = mmengine.ProgressBar(len(data_list))
+        for data in data_list:
+            sample_idx = data['sample_idx']
+            timestamp = data['timestamp']
+            context_name = tf_infos[timestamp]['context_name']
+            idx2metainfo[str(sample_idx)] = {
+                'contextname': context_name,
+                'timestamp': timestamp
+            }
+            prog_bar.update()
+        mmengine.dump(idx2metainfo, self.info_path)
+        print('saved idx2metainfo to ', self.info_path)
 
     def get_file_names(self):
         """Get file names of waymo raw data."""
@@ -136,143 +186,6 @@ class Prediction2Waymo(object):
     def create_folder(self):
         """Create folder for data conversion."""
         mmengine.mkdir_or_exist(self.waymo_results_save_dir)
-
-    def parse_objects(self, kitti_result, T_k2w, context_name,
-                      frame_timestamp_micros):
-        """Parse one prediction with several instances in kitti format and
-        convert them to `Object` proto.
-
-        Args:
-            kitti_result (dict): Predictions in kitti format.
-
-                - name (np.ndarray): Class labels of predictions.
-                - dimensions (np.ndarray): Height, width, length of boxes.
-                - location (np.ndarray): Bottom center of boxes (x, y, z).
-                - rotation_y (np.ndarray): Orientation of boxes.
-                - score (np.ndarray): Scores of predictions.
-            T_k2w (np.ndarray): Transformation matrix from kitti to waymo.
-            context_name (str): Context name of the frame.
-            frame_timestamp_micros (int): Frame timestamp.
-
-        Returns:
-            :obj:`Object`: Predictions in waymo dataset Object proto.
-        """
-
-        def parse_one_object(instance_idx):
-            """Parse one instance in kitti format and convert them to `Object`
-            proto.
-
-            Args:
-                instance_idx (int): Index of the instance to be converted.
-
-            Returns:
-                :obj:`Object`: Predicted instance in waymo dataset
-                    Object proto.
-            """
-            cls = kitti_result['name'][instance_idx]
-            length = round(kitti_result['dimensions'][instance_idx, 0], 4)
-            height = round(kitti_result['dimensions'][instance_idx, 1], 4)
-            width = round(kitti_result['dimensions'][instance_idx, 2], 4)
-            x = round(kitti_result['location'][instance_idx, 0], 4)
-            y = round(kitti_result['location'][instance_idx, 1], 4)
-            z = round(kitti_result['location'][instance_idx, 2], 4)
-            rotation_y = round(kitti_result['rotation_y'][instance_idx], 4)
-            score = round(kitti_result['score'][instance_idx], 4)
-
-            # y: downwards; move box origin from bottom center (kitti) to
-            # true center (waymo)
-            y -= height / 2
-            # frame transformation: kitti -> waymo
-            x, y, z = self.transform(T_k2w, x, y, z)
-
-            # different conventions
-            heading = -(rotation_y + np.pi / 2)
-            while heading < -np.pi:
-                heading += 2 * np.pi
-            while heading > np.pi:
-                heading -= 2 * np.pi
-
-            box = label_pb2.Label.Box()
-            box.center_x = x
-            box.center_y = y
-            box.center_z = z
-            box.length = length
-            box.width = width
-            box.height = height
-            box.heading = heading
-
-            o = metrics_pb2.Object()
-            o.object.box.CopyFrom(box)
-            o.object.type = self.k2w_cls_map[cls]
-            o.score = score
-
-            o.context_name = context_name
-            o.frame_timestamp_micros = frame_timestamp_micros
-
-            return o
-
-        objects = metrics_pb2.Objects()
-
-        for instance_idx in range(len(kitti_result['name'])):
-            o = parse_one_object(instance_idx)
-            objects.objects.append(o)
-
-        return objects
-
-    def convert_one(self, file_idx):
-        """Convert action for single file.
-
-        Args:
-            file_idx (int): Index of the file to be converted.
-        """
-        file_pathname = self.waymo_tfrecord_pathnames[file_idx]
-        if 's3://' in file_pathname and tf.__version__ >= '2.6.0':
-            try:
-                import tensorflow_io as tfio  # noqa: F401
-            except ImportError:
-                raise ImportError(
-                    "Please run 'pip install tensorflow-io' to install tensorflow_io first."  # noqa: E501
-                )
-        file_data = tf.data.TFRecordDataset(file_pathname, compression_type='')
-
-        for frame_num, frame_data in enumerate(file_data):
-            frame = open_dataset.Frame()
-            frame.ParseFromString(bytearray(frame_data.numpy()))
-
-            filename = f'{self.prefix}{file_idx:03d}{frame_num:03d}'
-
-            context_name = frame.context.name
-            frame_timestamp_micros = frame.timestamp_micros
-
-            if filename in self.name2idx:
-                if self.from_kitti_format:
-                    for camera in frame.context.camera_calibrations:
-                        # FRONT = 1, see dataset.proto for details
-                        if camera.name == 1:
-                            T_front_cam_to_vehicle = np.array(
-                                camera.extrinsic.transform).reshape(4, 4)
-
-                    T_k2w = T_front_cam_to_vehicle @ self.T_ref_to_front_cam
-
-                    kitti_result = \
-                        self.results[self.name2idx[filename]]
-                    objects = self.parse_objects(kitti_result, T_k2w,
-                                                 context_name,
-                                                 frame_timestamp_micros)
-                else:
-                    index = self.name2idx[filename]
-                    objects = self.parse_objects_from_origin(
-                        self.results[index], context_name,
-                        frame_timestamp_micros)
-
-            else:
-                print(filename, 'not found.')
-                objects = metrics_pb2.Objects()
-
-            with open(
-                    join(self.waymo_results_save_dir, f'{filename}.bin'),
-                    'wb') as f:
-                f.write(objects.SerializeToString())
 
     def convert_one_fast(self, res_index: int):
         """Convert action for single file. It read the metainfo from the
@@ -350,8 +263,6 @@ class Prediction2Waymo(object):
     def convert(self):
         """Convert action."""
         print('Start converting ...')
-        convert_func = self.convert_one_fast if self.fast_eval else \
-            self.convert_one
 
         # from torch.multiprocessing import set_sharing_strategy
         # # Force using "file_system" sharing strategy for stability
@@ -365,7 +276,7 @@ class Prediction2Waymo(object):
         # be seen in https://github.com/pytorch/pytorch/issues/67864.
         prog_bar = mmengine.ProgressBar(len(self))
         for i in range(len(self)):
-            convert_func(i)
+            self.convert_one_fast(i)
             prog_bar.update()
 
         print('\nFinished ...')
@@ -379,8 +290,7 @@ class Prediction2Waymo(object):
 
     def __len__(self):
         """Length of the filename list."""
-        return len(self.results) if self.fast_eval else len(
-            self.waymo_tfrecord_pathnames)
+        return len(self.results)
 
     def transform(self, T, x, y, z):
         """Transform the coordinates with matrix T.

--- a/mmdet3d/evaluation/metrics/waymo_metric.py
+++ b/mmdet3d/evaluation/metrics/waymo_metric.py
@@ -74,12 +74,13 @@ class WaymoMetric(KittiMetric):
 
     def __init__(self,
                  ann_file: str,
+                 load_interval: int,
                  waymo_bin_file: str,
                  data_root: str,
-                 split: str = 'training',
+                 split: str = 'validation',
                  metric: Union[str, List[str]] = 'mAP',
                  pcd_limit_range: List[float] = [-85, -85, -5, 85, 85, 5],
-                 convert_kitti_format: bool = True,
+                 convert_kitti_format: bool = False,
                  prefix: Optional[str] = None,
                  pklfile_prefix: str = None,
                  submission_prefix: str = None,
@@ -100,6 +101,7 @@ class WaymoMetric(KittiMetric):
             self.idx2metainfo = mmengine.load(idx2metainfo)
         else:
             self.idx2metainfo = None
+        self.load_interval = load_interval
 
         super().__init__(
             ann_file=ann_file,
@@ -127,7 +129,8 @@ class WaymoMetric(KittiMetric):
         self.classes = self.dataset_meta['classes']
 
         # load annotations
-        self.data_infos = load(self.ann_file)['data_list']
+        self.data_infos = load(
+            self.ann_file)['data_list'][::self.load_interval]
         assert len(results) == len(self.data_infos), \
             'invalid list length of network outputs'
         # different from kitti, waymo do not need to convert the ann file
@@ -186,6 +189,17 @@ class WaymoMetric(KittiMetric):
             tmp_dir.cleanup()
         return metric_dict
 
+    def generate_gt_bin(self):
+        from tools.dataset_converters.waymo_gtbin_creator import gt_bin_creator
+        creator = gt_bin_creator(
+            self.ann_file,
+            self.data_root,
+            self.split,
+            self.waymo_bin_file,
+            self.load_interval,
+            for_cam_only_challenge=True)
+        self.waymo_bin_file = creator.create_subset()
+
     def waymo_evaluate(self,
                        pklfile_prefix: str,
                        metric: str = None,
@@ -202,6 +216,7 @@ class WaymoMetric(KittiMetric):
         Returns:
             dict[str, float]: Results of each evaluation metric.
         """
+        self.generate_gt_bin()
 
         import subprocess
 
@@ -352,6 +367,9 @@ class WaymoMetric(KittiMetric):
 
         waymo_root = self.data_root
         if self.split == 'training':
+            waymo_tfrecords_dir = osp.join(waymo_root, 'training')
+            prefix = '0'
+        elif self.split == 'validation':
             waymo_tfrecords_dir = osp.join(waymo_root, 'validation')
             prefix = '1'
         elif self.split == 'testing':
@@ -371,7 +389,8 @@ class WaymoMetric(KittiMetric):
             classes,
             file_client_args=self.file_client_args,
             from_kitti_format=self.convert_kitti_format,
-            idx2metainfo=self.idx2metainfo)
+            idx2metainfo=self.idx2metainfo,
+            ann_file=self.ann_file)
         converter.convert()
         waymo_save_tmp_dir.cleanup()
 

--- a/tools/dataset_converters/waymo_gtbin_creator.py
+++ b/tools/dataset_converters/waymo_gtbin_creator.py
@@ -1,0 +1,172 @@
+import mmengine
+import tensorflow.compat.v1 as tf
+
+tf.enable_eager_execution()
+
+from glob import glob
+from os.path import exists, join
+
+from waymo_open_dataset import dataset_pb2 as open_dataset
+from waymo_open_dataset import label_pb2
+from waymo_open_dataset.protos import metrics_pb2
+
+
+class gt_bin_creator:
+
+    def __init__(
+        self,
+        ann_file,
+        data_root,
+        split,  #('training','validation')
+        waymo_bin_file=None,
+        load_interval=1,
+        for_cam_only_challenge=True,
+        file_client_args: dict = dict(backend='disk')):
+        self.ann_file = ann_file
+        self.waymo_bin_file = waymo_bin_file
+        self.data_root = data_root
+        self.split = split
+        self.load_interval = load_interval
+        self.for_cam_only_challenge = for_cam_only_challenge
+        self.file_client_args = file_client_args
+        self.waymo_tfrecords_dir = join(self.data_root, self.split)
+        if self.waymo_bin_file == None:
+            self.waymo_bin_file = join(self.data_root,
+                                       'gt_{}.bin'.format(self.split))
+
+    def get_target_timestamp(self):
+        data_infos = mmengine.load(
+            self.ann_file)['data_list'][::self.load_interval]
+        self.timestamp = set()
+        for info in data_infos:
+            self.timestamp.add(info['timestamp'])
+
+    def create_subset(self):
+        self.create_whole()
+
+        subset_path = \
+            self.waymo_bin_file.replace('.bin', f'_subset_{self.load_interval}.bin')
+        if exists(subset_path):
+            print(f'file {subset_path} exists. Skipping create_subset')
+        else:
+            print(f'Can not find {subset_path}, creating a new one...')
+            objs = metrics_pb2.Objects()
+            objs.ParseFromString(open(self.waymo_bin_file, 'rb').read())
+            self.get_target_timestamp()
+            objs_subset = metrics_pb2.Objects()
+            prog_bar = mmengine.ProgressBar(len(objs.objects))
+            for obj in objs.objects:
+                prog_bar.update()
+                if obj.frame_timestamp_micros not in self.timestamp: continue
+                if self.for_cam_only_challenge and \
+                   obj.object.type == label_pb2.Label.TYPE_SIGN:
+                    continue
+
+                objs_subset.objects.append(obj)
+
+            open(subset_path, 'wb').write(objs_subset.SerializeToString())
+            print(f'save subset bin file to {subset_path}')
+
+        return subset_path
+
+    def create_whole(self):
+        if exists(self.waymo_bin_file):
+            print(f'file {self.waymo_bin_file} exists. Skipping create_whole')
+        else:
+            print(f'Can not find {self.waymo_bin_file}, creating a new one...')
+            self.get_file_names()
+            tfnames = self.waymo_tfrecord_pathnames
+
+            objs = metrics_pb2.Objects()
+            frame_num = 0
+            prog_bar = mmengine.ProgressBar(len(tfnames))
+            for i in range(len(tfnames)):
+                dataset = tf.data.TFRecordDataset(
+                    tfnames[i], compression_type='')
+                for data in dataset:
+                    frame = open_dataset.Frame()
+                    frame.ParseFromString(bytearray(data.numpy()))
+                    frame_num += 1
+                    for label in frame.laser_labels:
+                        if self.for_cam_only_challenge and \
+                        (label.type == 3 or
+                        label.camera_synced_box.ByteSize() == 0 or
+                        label.num_lidar_points_in_box < 1):
+                            continue
+
+                        new_obj = metrics_pb2.Object()
+                        new_obj.frame_timestamp_micros = frame.timestamp_micros
+                        new_obj.object.CopyFrom(label)
+                        new_obj.context_name = frame.context.name
+                        objs.objects.append(new_obj)
+                prog_bar.update()
+
+            open(self.waymo_bin_file, 'wb').write(objs.SerializeToString())
+            print(f'Saved groudtruth bin file to {self.waymo_bin_file}\n\
+                    It has {len(objs.objects)} objects in {frame_num} frames.')
+
+        return self.waymo_bin_file
+
+    def get_file_names(self):
+        """Get file names of waymo raw data."""
+        if 'path_mapping' in self.file_client_args:
+            for path in self.file_client_args['path_mapping'].keys():
+                if path in self.waymo_tfrecords_dir:
+                    self.waymo_tfrecords_dir = \
+                        self.waymo_tfrecords_dir.replace(
+                            path, self.file_client_args['path_mapping'][path])
+            from petrel_client.client import Client
+            client = Client()
+            contents = client.list(self.waymo_tfrecords_dir)
+            self.waymo_tfrecord_pathnames = list()
+            for content in sorted(list(contents)):
+                if content.endswith('tfrecord'):
+                    self.waymo_tfrecord_pathnames.append(
+                        join(self.waymo_tfrecords_dir, content))
+        else:
+            self.waymo_tfrecord_pathnames = sorted(
+                glob(join(self.waymo_tfrecords_dir, '*.tfrecord')))
+        print(len(self.waymo_tfrecord_pathnames), 'tfrecords found.')
+
+
+from argparse import ArgumentParser
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--ann_file',
+        default='./data/waymo_dev1x/kitti_format/waymo_infos_val.pkl')
+    parser.add_argument(
+        '--data_root', default='./data/waymo_dev1x/waymo_format')
+    parser.add_argument(
+        '--split', default='validation')  #('training','validation')
+    # parser.add_argument('waymo_bin_file')
+    parser.add_argument('--load_interval', type=int, default=1)
+    parser.add_argument('--for_cam_only_challenge', default=True)
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    # test = './data/waymo_dev1x/waymo_format/gt.bin'
+    creator = gt_bin_creator(args.ann_file, args.data_root, args.split, None,
+                             args.load_interval, args.for_cam_only_challenge)
+    waymo_bin_file = creator.create_whole()
+    waymo_subset_bin_file = creator.create_subset()
+    # breakpoint()
+
+
+if __name__ == '__main__':
+    main()
+"""
+Usage:
+python tools/create_gt_bin.py \
+    --ann_file ./data/waymo_dev1x/kitti_format/waymo_infos_val.pkl \
+    --data_root ./data/waymo_dev1x/waymo_format \
+    --split validation \
+    --load_interval 1 \
+    --for_cam_only_challenge True
+"""


### PR DESCRIPTION
## Modification
1. Add `waymo_gtbin_creator.py` in `tools/dataset_converters/`
    - Support creating local gt_bin for evaluation. No need to download.
    - Support creating subset of gt_bin with the information in info pkl file.
    - Support creating normal gt_bin or the one for camera-only challenge.
2. Modified `waymo_metric.py`
    - Generate gt_bin if no gt_bin is found.
    - Support both training set evaluation for model debugging use.
    - Support `load_interval` in order to speed up evaluation.  For example, in config files, you can add `load_interval=10` to `val_dataloader` and `val_evaluator`. This is only for waymo evaluation.
    - self.split == 'training' no longer means val set evaluation.
3. Modified `prediction_to_waymo.py`
    - Generate `idx2metainfo.pkl` in `waymo_format/validation` automatically if not specified.
    - Delete slow converting function. Get everything fast!