### PR TITLE
Support waymo_info_test.pkl and ImageSets generating

### DIFF
--- a/tools/create_data.py
+++ b/tools/create_data.py
@@ -199,6 +199,10 @@ def waymo_data_prep(root_path,
             test_mode=(split
                        in ['testing', 'testing_3d_camera_only_detection']))
         converter.convert()
+
+    from tools.dataset_converters.waymo_converter import \
+        create_ImageSets_img_ids
+    create_ImageSets_img_ids(osp.join(out_dir, 'kitti_format'), splits)
     # Generate waymo infos
     out_dir = osp.join(out_dir, 'kitti_format')
     kitti.create_waymo_info_file(
@@ -206,9 +210,11 @@ def waymo_data_prep(root_path,
     info_train_path = osp.join(out_dir, f'{info_prefix}_infos_train.pkl')
     info_val_path = osp.join(out_dir, f'{info_prefix}_infos_val.pkl')
     info_trainval_path = osp.join(out_dir, f'{info_prefix}_infos_trainval.pkl')
+    test_path = osp.join(out_dir, f'{info_prefix}_infos_test.pkl')
     update_pkl_infos('waymo', out_dir=out_dir, pkl_path=info_train_path)
     update_pkl_infos('waymo', out_dir=out_dir, pkl_path=info_val_path)
     update_pkl_infos('waymo', out_dir=out_dir, pkl_path=info_trainval_path)
+    update_pkl_infos('waymo', out_dir=out_dir, pkl_path=test_path)
     GTDatabaseCreater(
         'WaymoDataset',
         out_dir,

--- a/tools/dataset_converters/kitti_data_utils.py
+++ b/tools/dataset_converters/kitti_data_utils.py
@@ -365,14 +365,14 @@ class WaymoInfoGatherer:
                 self.training,
                 self.relative_path,
                 use_prefix_id=True)
-            with open(
-                    get_timestamp_path(
-                        idx,
-                        self.path,
-                        self.training,
-                        relative_path=False,
-                        use_prefix_id=True)) as f:
-                info['timestamp'] = np.int64(f.read())
+        with open(
+                get_timestamp_path(
+                    idx,
+                    self.path,
+                    self.training,
+                    relative_path=False,
+                    use_prefix_id=True)) as f:
+            info['timestamp'] = np.int64(f.read())
         image_info['image_path'] = get_image_path(
             idx,
             self.path,


### PR DESCRIPTION
## Motivation

Currently, mmdet3d-dev1.x cannot generate waymo_info_test.pkl for testing or testing_camera_only properly.
This PR is aiming at fixing it.

## Modification

1.  create_data.py
    - Add function call `create_ImageSets_img_ids()` to generate ImageSets according to data in kitti_format/
    - Add function call `update_pkl_infos('waymo', out_dir=out_dir, pkl_path=test_path)` to update test info generated in `kitti.create_waymo_info_file(...)`
2. kitti_data_utils.py
    - Detach `timestamp` collecting from `velodyne_path` collecting. `timestamp` is very important link between kitti_format data and tfrecords data, so we still need to collect it even if no lidar data provided. PR #2179 also need timestamps in waymo_infos_*.pkl to generate idx2metainfo.pkl
3. updata_infos_to_v2.py
    - Use `dict.get(key)` methods instead of `dict[key]` methods to support updating info files without lidar data or annotations. Now function `update_waymo_infos`  is able to update `waymo_infos_test.pkl` or the camera-only one.
4. waymo_converter.py
    - Delete [this line](https://github.com/open-mmlab/mmdetection3d/compare/dev-1.x...ZLTJohn:mmdet3d-dev1x:pr-create_waymo_data?expand=1#diff-f278258f51ed0348df388285d5b3d72b06612aa51ed5ba66af4a1504f8f04654L135) and add `if range_image_top_pose is None: return` in function `save_lidar`. In this way, we don't need to judge if the split is camera_only or not. 
    - [TODO] We can also promt user that we lack lidar data in that split.
    - Add create_ImageSets_img_ids to support ImageSets generating.

## Issue

Currently the easiest way to generate `waymo camera-only test set pkl file` is renaming `testing_3d_camera_only_detection` to `testing`, and turn off `velodyne` in `WaymoInfoGatherer`. Actually, [simply adding an item](https://github.com/open-mmlab/mmdetection3d/blob/dev-1.x/tools/create_data.py#L186) could only generate cam-only test data in kitti_format but offers no pkl file. How do we plan to fix it?