### PR TITLE
[Fix] Fix the device mismatch error when torch version<1.11

### DIFF
--- a/mmdet3d/models/dense_heads/centerpoint_head.py
+++ b/mmdet3d/models/dense_heads/centerpoint_head.py
@@ -455,7 +455,7 @@ class CenterHead(BaseModule):
             (gt_bboxes_3d.gravity_center, gt_bboxes_3d.tensor[:, 3:]),
             dim=1).to(device)
         max_objs = self.train_cfg['max_objs'] * self.train_cfg['dense_reg']
-        grid_size = torch.tensor(self.train_cfg['grid_size'])
+        grid_size = torch.tensor(self.train_cfg['grid_size']).to(device)
         pc_range = torch.tensor(self.train_cfg['point_cloud_range'])
         voxel_size = torch.tensor(self.train_cfg['voxel_size'])
 


### PR DESCRIPTION
## Motivation

When the torch version<1.11, an error will be reported when executing the centerpoint model:
The error message is:
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!

This happens at centerpoint_head.py line542, due to center_int is saved on cuda, but feature_map_size is saved on the CPU.
``` python
if not (0 <= center_int[0] < feature_map_size[0]
        and 0 <= center_int[1] < feature_map_size[1]):
    continue
```

A more intuitive example:
``` python
>>> import torch
>>> torch.__version__
'1.8.0'
>>> a = torch.tensor([1])
>>> b = torch.tensor([2]).to('cuda')
>>> a<b
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```


## Modification

Make center_int and feature_map_size saved on the same device to avoid errors in the lower version of the torch.

## BC-breaking (Optional)

Not involved

## Use cases (Optional)

Not involved
