### PR TITLE
Fix device and slice

### DIFF
--- a/mmdet3d/core/bbox/structures/base_box3d.py
+++ b/mmdet3d/core/bbox/structures/base_box3d.py
@@ -324,6 +324,8 @@ class BaseInstance3DBoxes(object):
                 self.tensor[item].view(1, -1),
                 box_dim=self.box_dim,
                 with_yaw=self.with_yaw)
+        elif isinstance(item, torch.Tensor):
+            item = item.to(self.device)
         b = self.tensor[item]
         assert b.dim() == 2, \
             f'Indexing on Boxes with {item} failed to return a matrix!'

--- a/mmdet3d/models/dense_heads/train_mixins.py
+++ b/mmdet3d/models/dense_heads/train_mixins.py
@@ -139,7 +139,7 @@ class AnchorTrainMixin(object):
                 if self.assign_per_class:
                     gt_per_cls = (gt_labels == i)
                     anchor_targets = self.anchor_target_single_assigner(
-                        assigner, current_anchors, gt_bboxes[gt_per_cls, :],
+                        assigner, current_anchors, gt_bboxes[gt_per_cls],
                         gt_bboxes_ignore, gt_labels[gt_per_cls], input_meta,
                         num_classes, sampling)
                 else:


### PR DESCRIPTION
When I run:
``` shell
python tools/train.py configs/pointpillars/hv_pointpillars_secfpn_6x8_160e_kitti-3d-3class.py
```
I got such log:
``` log
  File "/home/ubuntu/workspace/datang/mmdetection/mmdet/core/utils/misc.py", line 30, in multi_apply
    return tuple(map(list, zip(*map_results)))
  File "/home/ubuntu/workspace/datang/mmdetection3d/mmdet3d/models/dense_heads/train_mixins.py", line 142, in anchor_target_3d_single
    assigner, current_anchors, gt_bboxes[gt_per_cls, :],
  File "/home/ubuntu/workspace/datang/mmdetection3d/mmdet3d/core/bbox/structures/base_box3d.py", line 327, in __getitem__
    b = self.tensor[item]
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```
It seems that the `gt_bboxes[gt_per_cls, :]` is wrong about slicing and item tensor device.