### PR TITLE
centerformer coordinates correspondence of gt box length and width

### DIFF
--- a/projects/CenterFormer/centerformer/centerformer_backbone.py
+++ b/projects/CenterFormer/centerformer/centerformer_backbone.py
@@ -659,16 +659,17 @@ class DeformableDecoderRPN(BaseDecoderRPN):
             for k in range(num_objs):
                 cls_id = task_classes[idx][k] - 1
 
-                width = task_boxes[idx][k][3]
-                length = task_boxes[idx][k][4]
-                width = width / voxel_size[0] / self.train_cfg[
+                # gt boxes [xyzlwhr]
+                length = task_boxes[idx][k][3]
+                width = task_boxes[idx][k][4]
+                length = length / voxel_size[0] / self.train_cfg[
                     'out_size_factor']
-                length = length / voxel_size[1] / self.train_cfg[
+                width = width / voxel_size[1] / self.train_cfg[
                     'out_size_factor']
 
                 if width > 0 and length > 0:
                     radius = gaussian_radius(
-                        (length, width),
+                        (width, length),
                         min_overlap=self.train_cfg['gaussian_overlap'])
                     radius = max(self.train_cfg['min_radius'], int(radius))
 
@@ -702,7 +703,7 @@ class DeformableDecoderRPN(BaseDecoderRPN):
                     rot = task_boxes[idx][k][6]
                     corner_keypoints = center_to_corner_box2d(
                         center.unsqueeze(0).cpu().numpy(),
-                        torch.tensor([[width, length]],
+                        torch.tensor([[length, width]],
                                      dtype=torch.float32).numpy(),
                         angles=rot,
                         origin=0.5)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Modification

mmdet3d coordinates are `xyzlwhr`, while in CenterFormer, `l` and `w` are opposite. This should be the same as mmdet3d coordinates.


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
