### PR TITLE
[Enhancement] Add type hints for mmdet3d/models/backbones/pointnet2_s…

### DIFF
--- a/mmdet3d/models/backbones/pointnet2_sa_msg.py
+++ b/mmdet3d/models/backbones/pointnet2_sa_msg.py
@@ -1,10 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Sequence, Tuple
+
 import torch
 from mmcv.cnn import ConvModule
 from torch import nn as nn
 
 from mmdet3d.models.layers.pointnet_modules import build_sa_module
 from mmdet3d.registry import MODELS
+from mmdet3d.utils import OptConfigType
 from .base_pointnet import BasePointNet
 
 
@@ -22,7 +25,7 @@ class PointNet2SAMSG(BasePointNet):
         sa_channels (tuple[tuple[int]]): Out channels of each mlp in SA module.
         aggregation_channels (tuple[int]): Out channels of aggregation
             multi-scale grouping features.
-        fps_mods (tuple[int]): Mod of FPS for each SA module.
+        fps_mods Sequence[Tuple[str]]: Mod of FPS for each SA module.
         fps_sample_range_lists (tuple[tuple[int]]): The number of sampling
             points which each SA module samples.
         dilated_group (tuple[bool]): Whether to use dilated ball query for
@@ -37,27 +40,42 @@ class PointNet2SAMSG(BasePointNet):
               each SA module.
     """
 
-    def __init__(self,
-                 in_channels,
-                 num_points=(2048, 1024, 512, 256),
-                 radii=((0.2, 0.4, 0.8), (0.4, 0.8, 1.6), (1.6, 3.2, 4.8)),
-                 num_samples=((32, 32, 64), (32, 32, 64), (32, 32, 32)),
-                 sa_channels=(((16, 16, 32), (16, 16, 32), (32, 32, 64)),
-                              ((64, 64, 128), (64, 64, 128), (64, 96, 128)),
-                              ((128, 128, 256), (128, 192, 256), (128, 256,
-                                                                  256))),
-                 aggregation_channels=(64, 128, 256),
-                 fps_mods=(('D-FPS'), ('FS'), ('F-FPS', 'D-FPS')),
-                 fps_sample_range_lists=((-1), (-1), (512, -1)),
-                 dilated_group=(True, True, True),
-                 out_indices=(2, ),
-                 norm_cfg=dict(type='BN2d'),
-                 sa_cfg=dict(
-                     type='PointSAModuleMSG',
-                     pool_mod='max',
-                     use_xyz=True,
-                     normalize_xyz=False),
-                 init_cfg=None):
+    def __init__(
+            self,
+            in_channels: int,
+            num_points: Sequence[int] = (2048, 1024, 512, 256),
+            radii: Sequence[Tuple[float, float, float]] = (
+                (0.2, 0.4, 0.8),
+                (0.4, 0.8, 1.6),
+                (1.6, 3.2, 4.8),
+            ),
+            num_samples: Sequence[Tuple[int, int,
+                                        int]] = ((32, 32, 64), (32, 32, 64),
+                                                 (32, 32, 32)),
+            sa_channels: Sequence[Sequence[Tuple[int, int,
+                                                 int]]] = (((16, 16,
+                                                             32), (16, 16, 32),
+                                                            (32, 32, 64)),
+                                                           ((64, 64, 128),
+                                                            (64, 64, 128),
+                                                            (64, 96, 128)),
+                                                           ((128, 128, 256),
+                                                            (128, 192, 256),
+                                                            (128, 256, 256))),
+            aggregation_channels: Sequence[int] = (64, 128, 256),
+            fps_mods: Sequence[Tuple[str]] = (('D-FPS'), ('FS'), ('F-FPS',
+                                                                  'D-FPS')),
+            fps_sample_range_lists: Sequence[Tuple[int]] = ((-1), (-1), (512,
+                                                                         -1)),
+            dilated_group: Tuple[bool] = (True, True, True),
+            out_indices: Sequence[int] = (2, ),
+            norm_cfg: dict = dict(type='BN2d'),
+            sa_cfg: dict = dict(
+                type='PointSAModuleMSG',
+                pool_mod='max',
+                use_xyz=True,
+                normalize_xyz=False),
+            init_cfg: OptConfigType = None):
         super().__init__(init_cfg=init_cfg)
         self.num_sa = len(sa_channels)
         self.out_indices = out_indices
@@ -123,7 +141,7 @@ class PointNet2SAMSG(BasePointNet):
                         bias=True))
                 sa_in_channel = cur_aggregation_channel
 
-    def forward(self, points):
+    def forward(self, points: torch.Tensor):
         """Forward pass.
 
         Args:

--- a/mmdet3d/models/layers/pointnet_modules/builder.py
+++ b/mmdet3d/models/layers/pointnet_modules/builder.py
@@ -4,7 +4,9 @@ from typing import Union
 from mmengine.registry import Registry
 from torch import nn as nn
 
-SA_MODULES = Registry('point_sa_module')
+SA_MODULES = Registry(
+    name='point_sa_module',
+    locations=['mmdet3d.models.layers.pointnet_modules'])
 
 
 def build_sa_module(cfg: Union[dict, None], *args, **kwargs) -> nn.Module:


### PR DESCRIPTION
…a_msg and Fix register warning

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. Add type hints for mmdet3d/models/backbones/pointnet2_sa_msg
2. fix warning "The "point_sa_module" registry in mmdet3d did not set import location. Fallback to call  `mmdet3d.utils.register_all_modules` instead.

## Modification

1. add type hints in mmdet3d/models/backbones/pointnet2_sa_msg.py
2. set location as params to Registry init methods, file is mmdet3d/models/layers/pointnet_modules/builder.py    
## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
5. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
6. The documentation has been modified accordingly, like docstring or example tutorials.
