### PR TITLE
[Feature] Support training and testing on Ascend NPU

### DIFF
--- a/mmdet3d/apis/train.py
+++ b/mmdet3d/apis/train.py
@@ -261,6 +261,8 @@ def train_detector(model,
 
     # fp16 setting
     fp16_cfg = cfg.get('fp16', None)
+    if fp16_cfg is None and cfg.get('device', None) == 'npu':
+        fp16_cfg = dict(loss_scale='dynamic')
     if fp16_cfg is not None:
         optimizer_config = Fp16OptimizerHook(
             **cfg.optimizer_config, **fp16_cfg, distributed=distributed)

--- a/mmdet3d/utils/util_distribution.py
+++ b/mmdet3d/utils/util_distribution.py
@@ -19,7 +19,13 @@ def build_dp(model, device='cuda', dim=0, *args, **kwargs):
     Returns:
         nn.Module: the model to be parallelized.
     """
-    if device == 'cuda':
+    if device == 'npu':
+        from mmcv.device.npu import NPUDataParallel
+        dp_factory['npu'] = NPUDataParallel
+        torch.npu.set_device(kwargs['device_ids'][0])
+        torch.npu.set_compile_mode(jit_compile=False)
+        model = model.npu()
+    elif device == 'cuda':
         model = model.cuda(kwargs['device_ids'][0])
     elif device == 'mlu':
         from mmcv.device.mlu import MLUDataParallel
@@ -42,8 +48,14 @@ def build_ddp(model, device='cuda', *args, **kwargs):
         .. [1] https://pytorch.org/docs/stable/generated/torch.nn.parallel.
                      DistributedDataParallel.html
     """
-    assert device in ['cuda', 'mlu'], 'Only available for cuda or mlu devices.'
-    if device == 'cuda':
+    assert device in ['cuda', 'mlu',
+                      'npu'], 'Only available for cuda or mlu or npu devices.'
+    if device == 'npu':
+        from mmcv.device.npu import NPUDistributedDataParallel
+        torch.npu.set_compile_mode(jit_compile=False)
+        ddp_factory['npu'] = NPUDistributedDataParallel
+        model = model.npu()
+    elif device == 'cuda':
         model = model.cuda()
     elif device == 'mlu':
         from mmcv.device.mlu import MLUDistributedDataParallel
@@ -51,6 +63,11 @@ def build_ddp(model, device='cuda', *args, **kwargs):
         model = model.mlu()
 
     return ddp_factory[device](model, *args, **kwargs)
+
+
+def is_npu_available():
+    """Returns a bool indicating if NPU is currently available."""
+    return hasattr(torch, 'npu') and torch.npu.is_available()
 
 
 def is_mlu_available():
@@ -61,6 +78,7 @@ def is_mlu_available():
 def get_device():
     """Returns an available device, cpu, cuda or mlu."""
     is_device_available = {
+        'npu': is_npu_available(),
         'cuda': torch.cuda.is_available(),
         'mlu': is_mlu_available()
     }

--- a/tools/test.py
+++ b/tools/test.py
@@ -207,6 +207,8 @@ def main():
     cfg.model.train_cfg = None
     model = build_model(cfg.model, test_cfg=cfg.get('test_cfg'))
     fp16_cfg = cfg.get('fp16', None)
+    if fp16_cfg is None and cfg.get('device', None) == 'npu':
+        fp16_cfg = dict(loss_scale='dynamic')
     if fp16_cfg is not None:
         wrap_fp16_model(model)
     checkpoint = load_checkpoint(model, args.checkpoint, map_location='cpu')


### PR DESCRIPTION
## Motivation

Support train and test on Ascend NPU for mmdetection3d. 

## Modification
+  Allow to get Ascend NPU device in get_device function.
+  Automatically enable fp16 when use Ascend NPU, since the NPU currently only supports mixed precision.

## BC-breaking (Optional)

Not involved.

## Use cases (Optional)

We have successfully run centerpoint on the NPU device, and the accuracy can be consistent with the GPU. We will supplement the corresponding documents and provide logs later.

config:centerpoint_02pillar_second_secfpn_4x8_cyclic_20e_nus.py
result:
![image](https://user-images.githubusercontent.com/12524287/227679261-7f101338-12c7-42b1-91cd-27e5168ba7b3.png)
