### PR TITLE
mmdet3d Docs update for registry location

### DIFF
--- a/mmdet3d/utils/setup_env.py
+++ b/mmdet3d/utils/setup_env.py
@@ -64,7 +64,7 @@ def register_all_modules(init_default_scope: bool = True) -> None:
             When `init_default_scope=True`, the global default scope will be
             set to `mmdet3d`, and all registries will build modules from mmdet3d's
             registry node. To understand more about the registry, please refer
-            to https://github.com/open-mmlab/mmengine/blob/main/docs/en/tutorials/registry.md
+            to https://github.com/open-mmlab/mmengine/blob/main/docs/en/advanced_tutorials/registry.md
             Defaults to True.
     """  # noqa
     import mmdet3d.datasets  # noqa: F401,F403


### PR DESCRIPTION
Registry docs are now under Advanced Tutorials.

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Changed doc location. I was looking for the docs and had to go find them myself.

## Modification

Updated the doc link for Registry in mmengine

## BC-breaking (Optional)

No, no breaking changes

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
