### PR TITLE
change cd to mmdetection3d from mmdetection to avoid docker build error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN pip install openmim && \
 # Install MMDetection3D
 RUN conda clean --all \
     && git clone https://github.com/open-mmlab/mmdetection3d.git -b dev-1.x /mmdetection3d \
-    && cd /mmdetection \
+    && cd /mmdetection3d \
     && pip install --no-cache-dir -e .
 
 WORKDIR /mmdetection3d


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix docker build issue. The present docker file is giving `cd: can't cd to /mmdetection` error while building 
## Modification

change the folder name from mmdetection to mmdetection3d 

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
