### PR TITLE
[Docs] Limit urllib3 version for docs building

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,3 +7,4 @@ sphinx-tabs
 sphinx_copybutton
 sphinx_markdown_tables>=0.0.16
 tabulate
+urllib3<2.0.0


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

![image](https://user-images.githubusercontent.com/55445986/237004449-87e2b161-a68d-4975-bc9e-82519462a12a.png)

![image](https://user-images.githubusercontent.com/55445986/237004853-6698df9b-e00b-425c-a4dc-993b95690e88.png)

This PR is created to fix the bug when building docs due to the high version of `urllib3`.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
