### PR TITLE
[FIX] avoid type error for box 3d object

### DIFF
--- a/projects/BEVFusion/bevfusion/transfusion_head.py
+++ b/projects/BEVFusion/bevfusion/transfusion_head.py
@@ -481,7 +481,7 @@ class TransFusionHead(nn.Module):
                     ret = dict(bboxes=boxes3d, scores=scores, labels=labels)
 
                 temp_instances = InstanceData()
-                temp_instances.bboxes_3d = metas[0]['box_type_3d'](
+                temp_instances.bboxes_3d = metas[0].box_type_3d(
                     ret['bboxes'], box_dim=ret['bboxes'].shape[-1])
                 temp_instances.scores_3d = ret['scores']
                 temp_instances.labels_3d = ret['labels'].int()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.
- avoid error below when testing
```
  File "/home/daisuke/workspace/mmdetection3d/projects/BEVFusion/bevfusion/transfusion_head.py", line 483, in predict_by_feat
    temp_instances.bboxes_3d = metas[0]['box_type_3d'](
TypeError: 'Det3DDataSample' object is not subscriptable
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
