### PR TITLE
HardSimpleVFE.forward() doesn't need args coors 

### DIFF
--- a/mmdet3d/models/detectors/voxelnet.py
+++ b/mmdet3d/models/detectors/voxelnet.py
@@ -37,8 +37,7 @@ class VoxelNet(SingleStage3DDetector):
         """Extract features from points."""
         voxel_dict = batch_inputs_dict['voxels']
         voxel_features = self.voxel_encoder(voxel_dict['voxels'],
-                                            voxel_dict['num_points'],
-                                            voxel_dict['coors'])
+                                            voxel_dict['num_points'])
         batch_size = voxel_dict['coors'][-1, 0].item() + 1
         x = self.middle_encoder(voxel_features, voxel_dict['coors'],
                                 batch_size)

--- a/mmdet3d/models/voxel_encoders/voxel_encoder.py
+++ b/mmdet3d/models/voxel_encoders/voxel_encoder.py
@@ -24,8 +24,8 @@ class HardSimpleVFE(nn.Module):
         super(HardSimpleVFE, self).__init__()
         self.num_features = num_features
 
-    def forward(self, features: Tensor, num_points: Tensor, coors: Tensor,
-                *args, **kwargs) -> Tensor:
+    def forward(self, features: Tensor, num_points: Tensor, *args,
+                **kwargs) -> Tensor:
         """Forward function.
 
         Args:
@@ -34,7 +34,6 @@ class HardSimpleVFE(nn.Module):
                 number of points inside a single voxel.
             num_points (torch.Tensor): Number of points in each voxel,
                  shape (N, ).
-            coors (torch.Tensor): Coordinates of voxels.
 
         Returns:
             torch.Tensor: Mean of points inside each voxel in shape (N, 3(4))


### PR DESCRIPTION
voxel coors are not involved with the process of HardSimpleVFE.forward(), so coors can be removed.

## Motivation
redudant args in code

## Modification
delete related args and the call to it.
