### PR TITLE
update the code of `train_pipeline` in the tutorial of nuScenes dataset.

### DIFF
--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -156,25 +156,19 @@ Intensity is not used by default due to its yielded noise when concatenating the
 A typical training pipeline of image-based 3D detection on nuScenes is as below.
 
 ```python
-train_pipeline = [
-    dict(type='LoadImageFromFileMono3D'),
-    dict(
-        type='LoadAnnotations3D',
-        with_bbox=True,
-        with_label=True,
-        with_attr_label=True,
-        with_bbox_3d=True,
-        with_label_3d=True,
-        with_bbox_depth=True),
-    dict(type='mmdet.Resize', scale=(1600, 900), keep_ratio=True),
-    dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
-    dict(
-        type='Pack3DDetInputs',
-        keys=[
-            'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
-            'gt_labels_3d', 'centers_2d', 'depths'
-        ]),
-]
+    train_pipeline = [
+        dict(type='LoadMultiViewImageFromFiles',
+             to_float32=True,
+             num_views=6),
+        dict(type='LoadAnnotations3D', ),
+        dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
+        dict(
+            type='Pack3DDetInputs',
+            keys=[
+                'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
+                'gt_labels_3d', 'centers_2d', 'depths'
+            ]),
+    ]
 ```
 
 It follows the general pipeline of 2D detection while differs in some details:

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -149,25 +149,19 @@ train_pipeline = [
 nuScenes 上基于图像的 3D 检测的典型训练流水线如下。
 
 ```python
-train_pipeline = [
-    dict(type='LoadImageFromFileMono3D'),
-    dict(
-        type='LoadAnnotations3D',
-        with_bbox=True,
-        with_label=True,
-        with_attr_label=True,
-        with_bbox_3d=True,
-        with_label_3d=True,
-        with_bbox_depth=True),
-    dict(type='mmdet.Resize', img_scale=(1600, 900), keep_ratio=True),
-    dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
-    dict(
-        type='Pack3DDetInputs',
-        keys=[
-            'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
-            'gt_labels_3d', 'centers_2d', 'depths'
-        ]),
-]
+    train_pipeline = [
+        dict(type='LoadMultiViewImageFromFiles',
+             to_float32=True,
+             num_views=6),
+        dict(type='LoadAnnotations3D', ),
+        dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
+        dict(
+            type='Pack3DDetInputs',
+            keys=[
+                'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
+                'gt_labels_3d', 'centers_2d', 'depths'
+            ]),
+    ]
 ```
 
 它遵循 2D 检测的一般流水线，但在一些细节上有所不同：


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

I was learning to use `mmdetction3d`. When I was trying to use sample codes in the tutorial of NuScenes Dataset, the samples were not accessible from the dataset by index. I looked into the tracebacks and found the `train_pipeline` has not been quite updated. To avoid similar problem other beginners may encounter, I want to update the tutorial

## Modification

Please briefly describe what modification is made in this PR.

Update the `train_pipeline` definition.

- `LoadImageFromFileMono3D` should be replaced by `LoadMultiViewImageFromFiles`. It's been discussed in many issues.
- `LoadAnnotations3D` is set to default, otherwise there would be tracebacks, for example, the following traceback will happen if `with_bbox=True`:
```
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmdet/datasets/transforms/loading.py", line 396, in transform
    self._load_bboxes(results)
  File "/home/yangyi/wd/git_repo/mmdetection3d/mmdet3d/datasets/transforms/loading.py", line 1033, in _load_bboxes
    results['gt_bboxes'] = results['ann_info']['gt_bboxes']
KeyError: 'gt_bboxes'
```
- `mmdet.Resize` is removed. The `mmdet.Resize` directly change `results['img']` as a `numpy.ndarray`, while in 3D detection, `result['img']` is a list of `numpy.ndarray`, the following traceback would happen:
```
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmdet/datasets/transforms/transforms.py", line 154, in transform
    self._resize_img(results)
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmcv/transforms/processing.py", line 172, in _resize_img
    img, scale_factor = mmcv.imrescale(
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmcv/image/geometric.py", line 279, in imrescale
    h, w = img.shape[:2]
AttributeError: 'list' object has no attribute 'shape'
```

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
