### PR TITLE
[Docs] Add BEV-based detection pipeline in NuScenes Dataset tutorial

### DIFF
--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -184,7 +184,7 @@ It follows the general pipeline of 2D detection while differs in some details:
 - Some data augmentation techniques need to be adjusted, such as `RandomFlip3D`.
   Currently we do not support more augmentation methods, because how to transfer and apply other techniques is still under explored.
 
-Alternatively, BEV, Bird's-Eye-View, is another popular 3D detection method. It takes multiple surrounding views of ego vehicle to perform 3D detection, for nuScenes, it's CAM_FRONT, CAM_FRONT_LEFT, CAM_FRONT_RIGHT, CAM_BACK, CAM_BACK_LEFT and CAM_BACK_RIGHT. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
+Alternatively, BEV, Bird's-Eye-View, is another popular 3D detection method. It takes multiple surrounding views of ego vehicle to perform 3D detection, for nuScenes, they are CAM_FRONT, CAM_FRONT_LEFT, CAM_FRONT_RIGHT, CAM_BACK, CAM_BACK_LEFT and CAM_BACK_RIGHT. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
 
 ```python
     train_pipeline = [

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -161,7 +161,6 @@ A typical training pipeline of image-based 3D detection on nuScenes is as below.
              to_float32=True,
              num_views=6),
         dict(type='LoadAnnotations3D', ),
-        dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
         dict(
             type='Pack3DDetInputs',
             keys=[

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -212,7 +212,7 @@ train_pipeline = [
          with_bbox_3d=True,
          with_label_3d=True,
          with_attr_label=False),
-    # optional augmentation
+    # optional, data augmentation
     dict(type='MultiViewWrapper', transforms=train_transforms),
     # optional, filter object within specific point cloud range
     dict(type='ObjectRangeFilter', point_cloud_range=point_cloud_range),

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -153,7 +153,7 @@ Intensity is not used by default due to its yielded noise when concatenating the
 
 ### Vision-Based Methods
 
-A typical training pipeline of monocular image-based 3D detection on nuScenes is as below.
+A typical training pipeline of image-based monocular 3D detection on nuScenes is as below.
 
 ```python
 train_pipeline = [

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -156,25 +156,19 @@ Intensity is not used by default due to its yielded noise when concatenating the
 A typical training pipeline of image-based 3D detection on nuScenes is as below.
 
 ```python
-train_pipeline = [
-    dict(type='LoadImageFromFileMono3D'),
-    dict(
-        type='LoadAnnotations3D',
-        with_bbox=True,
-        with_label=True,
-        with_attr_label=True,
-        with_bbox_3d=True,
-        with_label_3d=True,
-        with_bbox_depth=True),
-    dict(type='mmdet.Resize', scale=(1600, 900), keep_ratio=True),
-    dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
-    dict(
-        type='Pack3DDetInputs',
-        keys=[
-            'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
-            'gt_labels_3d', 'centers_2d', 'depths'
-        ]),
-]
+    train_pipeline = [
+        dict(type='LoadMultiViewImageFromFiles',
+             to_float32=True,
+             num_views=6),
+        dict(type='LoadAnnotations3D', ),
+        dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
+        dict(
+            type='Pack3DDetInputs',
+            keys=[
+                'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
+                'gt_labels_3d', 'centers_2d', 'depths'
+            ]),
+    ]
 ```
 
 It follows the general pipeline of 2D detection while differs in some details:

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -153,8 +153,9 @@ Intensity is not used by default due to its yielded noise when concatenating the
 
 ### Vision-Based Methods
 
-1. Monocular-based
-   In the NuScenes dataset, for multi-view images, this paradigm usually involves detecting and outputting 3D object detection results separately for each image, and then obtaining the final detection results through post-processing (such as NMS). Essentially, it directly extends monocular 3D detection to multi-view settings. A typical training pipeline of image-based monocular 3D detection on nuScenes is as below.
+#### Monocular-based
+
+In the NuScenes dataset, for multi-view images, this paradigm usually involves detecting and outputting 3D object detection results separately for each image, and then obtaining the final detection results through post-processing (such as NMS). Essentially, it directly extends monocular 3D detection to multi-view settings. A typical training pipeline of image-based monocular 3D detection on nuScenes is as below.
 
 ```python
 train_pipeline = [
@@ -185,38 +186,66 @@ It follows the general pipeline of 2D detection while differs in some details:
 - Some data augmentation techniques need to be adjusted, such as `RandomFlip3D`.
   Currently we do not support more augmentation methods, because how to transfer and apply other techniques is still under explored.
 
-2. BEV-based
-   BEV, Bird's-Eye-View, is another popular 3D detection paradigm. It directly takes multi-view images to perform 3D detection, for nuScenes, they are `CAM_FRONT`, `CAM_FRONT_LEFT`, `CAM_FRONT_RIGHT`, `CAM_BACK`, `CAM_BACK_LEFT` and `CAM_BACK_RIGHT`. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
+#### BEV-based
+
+BEV, Bird's-Eye-View, is another popular 3D detection paradigm. It directly takes multi-view images to perform 3D detection, for nuScenes, they are `CAM_FRONT`, `CAM_FRONT_LEFT`, `CAM_FRONT_RIGHT`, `CAM_BACK`, `CAM_BACK_LEFT` and `CAM_BACK_RIGHT`. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
 
 ```python
-    train_pipeline = [
-        dict(type='LoadMultiViewImageFromFiles',
-             to_float32=True, num_views=6),
-        dict(type='LoadAnnotations3D', ),
-        dict(type='Pack3DDetInputs',
-             keys=['img', 'gt_bboxes_3d', 'gt_labels_3d', ]),
-    ]
+class_names = [
+    'car', 'truck', 'construction_vehicle', 'bus', 'trailer', 'barrier',
+    'motorcycle', 'bicycle', 'pedestrian', 'traffic_cone'
+]
+point_cloud_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+train_transforms = [
+    dict(type='PhotoMetricDistortion3D'),
+    dict(
+        type='RandomResize3D',
+        scale=(1600, 900),
+        ratio_range=(1., 1.),
+        keep_ratio=True)
+]
+train_pipeline = [
+    dict(type='LoadMultiViewImageFromFiles',
+         to_float32=True,
+         num_views=6, ),
+    dict(type='LoadAnnotations3D',
+         with_bbox_3d=True,
+         with_label_3d=True,
+         with_attr_label=False),
+    # optional augmentation
+    dict(type='MultiViewWrapper', transforms=train_transforms),
+    # optional, filter object within specific point cloud range
+    dict(type='ObjectRangeFilter', point_cloud_range=point_cloud_range),
+    # optional, filter object of specific classes
+    dict(type='ObjectNameFilter', classes=class_names),
+    dict(type='Pack3DDetInputs', keys=['img', 'gt_bboxes_3d', 'gt_labels_3d'])
+]
 ```
 
 To load multiple view of images, a little modification should be made to the dataset.
 
 ```python
 data_prefix = dict(
-    pts='samples/LIDAR_TOP',
     CAM_FRONT='samples/CAM_FRONT',
     CAM_FRONT_LEFT='samples/CAM_FRONT_LEFT',
     CAM_FRONT_RIGHT='samples/CAM_FRONT_RIGHT',
     CAM_BACK='samples/CAM_BACK',
     CAM_BACK_RIGHT='samples/CAM_BACK_RIGHT',
     CAM_BACK_LEFT='samples/CAM_BACK_LEFT',
-    sweeps='sweeps/LIDAR_TOP')
-
-dataset = NuScenesDataset(data_root="./data/nuScenes",
-                          ann_file="nuscenes_infos_train.pkl",
-                          data_prefix=data_prefix,
-                          modality=dict(use_camera=True, use_lidar=False, ),
-                          pipeline=train_pipeline,
-                          test_mode=False, )
+)
+train_dataloader = dict(
+    batch_size=4,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type="NuScenesDataset",
+        data_root="./data/nuScenes",
+        ann_file="nuscenes_infos_train.pkl",
+        data_prefix=data_prefix,
+        modality=dict(use_camera=True, use_lidar=False, ),
+        pipeline=train_pipeline,
+        test_mode=False, )
+)
 ```
 
 ## Evaluation

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -186,7 +186,7 @@ It follows the general pipeline of 2D detection while differs in some details:
   Currently we do not support more augmentation methods, because how to transfer and apply other techniques is still under explored.
 
 2. BEV-based
-BEV, Bird's-Eye-View, is another popular 3D detection paradigm. It directly takes multi-view images to perform 3D detection, for nuScenes, they are `CAM_FRONT`, `CAM_FRONT_LEFT`, `CAM_FRONT_RIGHT`, `CAM_BACK`, `CAM_BACK_LEFT` and `CAM_BACK_RIGHT`. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
+  BEV, Bird's-Eye-View, is another popular 3D detection paradigm. It directly takes multi-view images to perform 3D detection, for nuScenes, they are `CAM_FRONT`, `CAM_FRONT_LEFT`, `CAM_FRONT_RIGHT`, `CAM_BACK`, `CAM_BACK_LEFT` and `CAM_BACK_RIGHT`. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
 
 ```python
     train_pipeline = [

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -153,7 +153,8 @@ Intensity is not used by default due to its yielded noise when concatenating the
 
 ### Vision-Based Methods
 
-A typical training pipeline of image-based monocular 3D detection on nuScenes is as below.
+1. Monocular-based
+  In the NuScenes dataset, for multi-view images, this paradigm usually involves detecting and outputting 3D object detection results separately for each image, and then obtaining the final detection results through post-processing (such as NMS). Essentially, it directly extends monocular 3D detection to multi-view settings. A typical training pipeline of image-based monocular 3D detection on nuScenes is as below.
 
 ```python
 train_pipeline = [
@@ -184,7 +185,8 @@ It follows the general pipeline of 2D detection while differs in some details:
 - Some data augmentation techniques need to be adjusted, such as `RandomFlip3D`.
   Currently we do not support more augmentation methods, because how to transfer and apply other techniques is still under explored.
 
-Alternatively, BEV, Bird's-Eye-View, is another popular 3D detection method. It takes multiple surrounding views of ego vehicle to perform 3D detection, for nuScenes, they are CAM_FRONT, CAM_FRONT_LEFT, CAM_FRONT_RIGHT, CAM_BACK, CAM_BACK_LEFT and CAM_BACK_RIGHT. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
+2. BEV-based
+BEV, Bird's-Eye-View, is another popular 3D detection paradigm. It directly takes multi-view images to perform 3D detection, for nuScenes, they are `CAM_FRONT`, `CAM_FRONT_LEFT`, `CAM_FRONT_RIGHT`, `CAM_BACK`, `CAM_BACK_LEFT` and `CAM_BACK_RIGHT`. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
 
 ```python
     train_pipeline = [

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -154,7 +154,7 @@ Intensity is not used by default due to its yielded noise when concatenating the
 ### Vision-Based Methods
 
 1. Monocular-based
-  In the NuScenes dataset, for multi-view images, this paradigm usually involves detecting and outputting 3D object detection results separately for each image, and then obtaining the final detection results through post-processing (such as NMS). Essentially, it directly extends monocular 3D detection to multi-view settings. A typical training pipeline of image-based monocular 3D detection on nuScenes is as below.
+   In the NuScenes dataset, for multi-view images, this paradigm usually involves detecting and outputting 3D object detection results separately for each image, and then obtaining the final detection results through post-processing (such as NMS). Essentially, it directly extends monocular 3D detection to multi-view settings. A typical training pipeline of image-based monocular 3D detection on nuScenes is as below.
 
 ```python
 train_pipeline = [
@@ -186,7 +186,7 @@ It follows the general pipeline of 2D detection while differs in some details:
   Currently we do not support more augmentation methods, because how to transfer and apply other techniques is still under explored.
 
 2. BEV-based
-  BEV, Bird's-Eye-View, is another popular 3D detection paradigm. It directly takes multi-view images to perform 3D detection, for nuScenes, they are `CAM_FRONT`, `CAM_FRONT_LEFT`, `CAM_FRONT_RIGHT`, `CAM_BACK`, `CAM_BACK_LEFT` and `CAM_BACK_RIGHT`. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
+   BEV, Bird's-Eye-View, is another popular 3D detection paradigm. It directly takes multi-view images to perform 3D detection, for nuScenes, they are `CAM_FRONT`, `CAM_FRONT_LEFT`, `CAM_FRONT_RIGHT`, `CAM_BACK`, `CAM_BACK_LEFT` and `CAM_BACK_RIGHT`. A basic training pipeline of bev-based 3D detection on nuScenes is as below.
 
 ```python
     train_pipeline = [

--- a/docs/en/advanced_guides/datasets/nuscenes.md
+++ b/docs/en/advanced_guides/datasets/nuscenes.md
@@ -208,7 +208,7 @@ data_prefix = dict(
     CAM_BACK_RIGHT='samples/CAM_BACK_RIGHT',
     CAM_BACK_LEFT='samples/CAM_BACK_LEFT',
     sweeps='sweeps/LIDAR_TOP')
-    
+
 dataset = NuScenesDataset(data_root="./data/nuScenes",
                           ann_file="nuscenes_infos_train.pkl",
                           data_prefix=data_prefix,

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -204,11 +204,11 @@ train_pipeline = [
          with_bbox_3d=True,
          with_label_3d=True,
          with_attr_label=False),
-    # optional augmentation
+    # 可选，数据增强
     dict(type='MultiViewWrapper', transforms=train_transforms),
-    # optional, filter object within specific point cloud range
+    # 可选, 筛选特定点云范围内物体
     dict(type='ObjectRangeFilter', point_cloud_range=point_cloud_range),
-    # optional, filter object of specific classes
+    # 可选, 筛选特定类别物体
     dict(type='ObjectNameFilter', classes=class_names),
     dict(type='Pack3DDetInputs', keys=['img', 'gt_bboxes_3d', 'gt_labels_3d'])
 ]

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -146,8 +146,9 @@ train_pipeline = [
 
 ### 基于视觉的方法
 
-1. 基于单目方法
-   在NuScenes数据集中，对于多视角图像，单目检测范式通常由针对每张图像检测和输出 3D 检测结果以及通过后处理（例如 NMS ）得到最终检测结果两步组成。从本质上来说，这种范式直接将单目 3D 检测扩展到多视角任务。NuScenes 上基于图像的 3D 检测的典型训练流水线如下。
+#### 基于单目方法
+
+在NuScenes数据集中，对于多视角图像，单目检测范式通常由针对每张图像检测和输出 3D 检测结果以及通过后处理（例如 NMS ）得到最终检测结果两步组成。从本质上来说，这种范式直接将单目 3D 检测扩展到多视角任务。NuScenes 上基于图像的 3D 检测的典型训练流水线如下。
 
 ```python
 train_pipeline = [
@@ -177,38 +178,66 @@ train_pipeline = [
 - 它需要加载 3D 标注。
 - 一些数据增强技术需要调整，例如`RandomFlip3D`。目前我们不支持更多的增强方法，因为如何迁移和应用其他技术仍在探索中。
 
-2. 基于BEV方法
-   鸟瞰图，BEV（Bird's-Eye-View），是另一种常用的 3D 检测范式。它直接利用多个视角图像进行 3D 检测。对于 NuScenes 数据集而言，这些视角包括前方`CAM_FRONT`、左前方`CAM_FRONT_LEFT`、右前方`CAM_FRONT_RIGHT`、后方`CAM_BACK`、左后方`CAM_BACK_LEFT`、右后方`CAM_BACK_RIGHT`。一个基本的用于 BEV 方法的流水线如下。
+#### 基于BEV方法
+
+鸟瞰图，BEV（Bird's-Eye-View），是另一种常用的 3D 检测范式。它直接利用多个视角图像进行 3D 检测。对于 NuScenes 数据集而言，这些视角包括前方`CAM_FRONT`、左前方`CAM_FRONT_LEFT`、右前方`CAM_FRONT_RIGHT`、后方`CAM_BACK`、左后方`CAM_BACK_LEFT`、右后方`CAM_BACK_RIGHT`。一个基本的用于 BEV 方法的流水线如下。
 
 ```python
-    train_pipeline = [
-        dict(type='LoadMultiViewImageFromFiles',
-             to_float32=True, num_views=6),
-        dict(type='LoadAnnotations3D', ),
-        dict(type='Pack3DDetInputs',
-             keys=['img', 'gt_bboxes_3d', 'gt_labels_3d', ]),
-    ]
+class_names = [
+    'car', 'truck', 'construction_vehicle', 'bus', 'trailer', 'barrier',
+    'motorcycle', 'bicycle', 'pedestrian', 'traffic_cone'
+]
+point_cloud_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+train_transforms = [
+    dict(type='PhotoMetricDistortion3D'),
+    dict(
+        type='RandomResize3D',
+        scale=(1600, 900),
+        ratio_range=(1., 1.),
+        keep_ratio=True)
+]
+train_pipeline = [
+    dict(type='LoadMultiViewImageFromFiles',
+         to_float32=True,
+         num_views=6, ),
+    dict(type='LoadAnnotations3D',
+         with_bbox_3d=True,
+         with_label_3d=True,
+         with_attr_label=False),
+    # optional augmentation
+    dict(type='MultiViewWrapper', transforms=train_transforms),
+    # optional, filter object within specific point cloud range
+    dict(type='ObjectRangeFilter', point_cloud_range=point_cloud_range),
+    # optional, filter object of specific classes
+    dict(type='ObjectNameFilter', classes=class_names),
+    dict(type='Pack3DDetInputs', keys=['img', 'gt_bboxes_3d', 'gt_labels_3d'])
+]
 ```
 
 为了读取多个视角的图像，数据集也应进行相应微调。
 
 ```python
 data_prefix = dict(
-    pts='samples/LIDAR_TOP',
     CAM_FRONT='samples/CAM_FRONT',
     CAM_FRONT_LEFT='samples/CAM_FRONT_LEFT',
     CAM_FRONT_RIGHT='samples/CAM_FRONT_RIGHT',
     CAM_BACK='samples/CAM_BACK',
     CAM_BACK_RIGHT='samples/CAM_BACK_RIGHT',
     CAM_BACK_LEFT='samples/CAM_BACK_LEFT',
-    sweeps='sweeps/LIDAR_TOP')
-
-dataset = NuScenesDataset(data_root="./data/nuScenes",
-                          ann_file="nuscenes_infos_train.pkl",
-                          data_prefix=data_prefix,
-                          modality=dict(use_camera=True, use_lidar=False, ),
-                          pipeline=train_pipeline,
-                          test_mode=False, )
+)
+train_dataloader = dict(
+    batch_size=4,
+    persistent_workers=True,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
+        type="NuScenesDataset",
+        data_root="./data/nuScenes",
+        ann_file="nuscenes_infos_train.pkl",
+        data_prefix=data_prefix,
+        modality=dict(use_camera=True, use_lidar=False, ),
+        pipeline=train_pipeline,
+        test_mode=False, )
+)
 ```
 
 ## 评估

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -147,7 +147,7 @@ train_pipeline = [
 ### 基于视觉的方法
 
 1. 基于单目方法
-  在NuScenes数据集中，对于多视角图像，单目检测范式通常由针对每张图像检测和输出 3D 检测结果以及通过后处理（例如 NMS ）得到最终检测结果两步组成。从本质上来说，这种范式直接将单目 3D 检测扩展到多视角任务。NuScenes 上基于图像的 3D 检测的典型训练流水线如下。
+   在NuScenes数据集中，对于多视角图像，单目检测范式通常由针对每张图像检测和输出 3D 检测结果以及通过后处理（例如 NMS ）得到最终检测结果两步组成。从本质上来说，这种范式直接将单目 3D 检测扩展到多视角任务。NuScenes 上基于图像的 3D 检测的典型训练流水线如下。
 
 ```python
 train_pipeline = [
@@ -178,7 +178,7 @@ train_pipeline = [
 - 一些数据增强技术需要调整，例如`RandomFlip3D`。目前我们不支持更多的增强方法，因为如何迁移和应用其他技术仍在探索中。
 
 2. 基于BEV方法
-   鸟瞰图，BEV（Bird's-Eye-View），是另一种常用的 3D 检测范式。 它直接利用多个视角图像进行 3D 检测。对于 nuScenes 数据集而言，这些视角包括前方`CAM_FRONT`、左前方`CAM_FRONT_LEFT`、右前方`CAM_FRONT_RIGHT`、后方`CAM_BACK`、左后方`CAM_BACK_LEFT`、右后方`CAM_BACK_RIGHT`。一个基本的用于 BEV 方法的流水线如下。
+   鸟瞰图，BEV（Bird's-Eye-View），是另一种常用的 3D 检测范式。它直接利用多个视角图像进行 3D 检测。对于 NuScenes 数据集而言，这些视角包括前方`CAM_FRONT`、左前方`CAM_FRONT_LEFT`、右前方`CAM_FRONT_RIGHT`、后方`CAM_BACK`、左后方`CAM_BACK_LEFT`、右后方`CAM_BACK_RIGHT`。一个基本的用于 BEV 方法的流水线如下。
 
 ```python
     train_pipeline = [

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -149,25 +149,19 @@ train_pipeline = [
 nuScenes 上基于图像的 3D 检测的典型训练流水线如下。
 
 ```python
-train_pipeline = [
-    dict(type='LoadImageFromFileMono3D'),
-    dict(
-        type='LoadAnnotations3D',
-        with_bbox=True,
-        with_label=True,
-        with_attr_label=True,
-        with_bbox_3d=True,
-        with_label_3d=True,
-        with_bbox_depth=True),
-    dict(type='mmdet.Resize', img_scale=(1600, 900), keep_ratio=True),
-    dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
-    dict(
-        type='Pack3DDetInputs',
-        keys=[
-            'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
-            'gt_labels_3d', 'centers_2d', 'depths'
-        ]),
-]
+    train_pipeline = [
+        dict(type='LoadMultiViewImageFromFiles',
+             to_float32=True,
+             num_views=6),
+        dict(type='LoadAnnotations3D', ),
+        dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
+        dict(
+            type='Pack3DDetInputs',
+            keys=[
+                'img', 'gt_bboxes', 'gt_bboxes_labels', 'attr_labels', 'gt_bboxes_3d',
+                'gt_labels_3d', 'centers_2d', 'depths'
+            ]),
+    ]
 ```
 
 它遵循 2D 检测的一般流水线，但在一些细节上有所不同：

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -146,7 +146,8 @@ train_pipeline = [
 
 ### 基于视觉的方法
 
-nuScenes 上基于图像的单目 3D 检测的典型训练流水线如下。
+1. 基于单目方法
+  在NuScenes数据集中，对于多视角图像，单目检测范式通常由针对每张图像检测和输出 3D 检测结果以及通过后处理（例如 NMS ）得到最终检测结果两步组成。从本质上来说，这种范式直接将单目 3D 检测扩展到多视角任务。NuScenes 上基于图像的 3D 检测的典型训练流水线如下。
 
 ```python
 train_pipeline = [
@@ -176,7 +177,8 @@ train_pipeline = [
 - 它需要加载 3D 标注。
 - 一些数据增强技术需要调整，例如`RandomFlip3D`。目前我们不支持更多的增强方法，因为如何迁移和应用其他技术仍在探索中。
 
-同时, 鸟瞰图，BEV（Bird's-Eye-View），是另一种常见的 3D 检测方法。 它利用环绕自车的多个视角图像进行 3D 检测。对于 nuScenes 数据集而言，这些视角包括前方、左前方、右前方、后方、左后方、右后方。一个基本的用于 BEV 方法的流水线如下。
+2. 基于BEV方法
+   鸟瞰图，BEV（Bird's-Eye-View），是另一种常用的 3D 检测范式。 它直接利用多个视角图像进行 3D 检测。对于 nuScenes 数据集而言，这些视角包括前方`CAM_FRONT`、左前方`CAM_FRONT_LEFT`、右前方`CAM_FRONT_RIGHT`、后方`CAM_BACK`、左后方`CAM_BACK_LEFT`、右后方`CAM_BACK_RIGHT`。一个基本的用于 BEV 方法的流水线如下。
 
 ```python
     train_pipeline = [

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -200,7 +200,7 @@ data_prefix = dict(
     CAM_BACK_RIGHT='samples/CAM_BACK_RIGHT',
     CAM_BACK_LEFT='samples/CAM_BACK_LEFT',
     sweeps='sweeps/LIDAR_TOP')
-    
+
 dataset = NuScenesDataset(data_root="./data/nuScenes",
                           ann_file="nuscenes_infos_train.pkl",
                           data_prefix=data_prefix,

--- a/docs/zh_cn/advanced_guides/datasets/nuscenes.md
+++ b/docs/zh_cn/advanced_guides/datasets/nuscenes.md
@@ -154,7 +154,6 @@ nuScenes 上基于图像的 3D 检测的典型训练流水线如下。
              to_float32=True,
              num_views=6),
         dict(type='LoadAnnotations3D', ),
-        dict(type='RandomFlip3D', flip_ratio_bev_horizontal=0.5),
         dict(
             type='Pack3DDetInputs',
             keys=[


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

I was learning to use `mmdetction3d`. When I was trying to use sample codes in the tutorial of NuScenes Dataset, the samples were not accessible from the dataset by index. I looked into the tracebacks and found the `train_pipeline` has not been quite updated. To avoid similar problem other beginners may encounter, I want to update the tutorial

## Modification

Please briefly describe what modification is made in this PR.

Update the `train_pipeline` definition.

- `LoadImageFromFileMono3D` should be replaced by `LoadMultiViewImageFromFiles`. It's been discussed in many issues.
- `LoadAnnotations3D` is set to default, otherwise there would be tracebacks, for example, the following traceback will happen if `with_bbox=True`:
```
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmdet/datasets/transforms/loading.py", line 396, in transform
    self._load_bboxes(results)
  File "/home/yangyi/wd/git_repo/mmdetection3d/mmdet3d/datasets/transforms/loading.py", line 1033, in _load_bboxes
    results['gt_bboxes'] = results['ann_info']['gt_bboxes']
KeyError: 'gt_bboxes'
```
- `mmdet.Resize` is removed. The `mmdet.Resize` directly change `results['img']` as a `numpy.ndarray`, while in 3D detection, `result['img']` is a list of `numpy.ndarray`, the following traceback would happen:
```
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmdet/datasets/transforms/transforms.py", line 154, in transform
    self._resize_img(results)
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmcv/transforms/processing.py", line 172, in _resize_img
    img, scale_factor = mmcv.imrescale(
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmcv/image/geometric.py", line 279, in imrescale
    h, w = img.shape[:2]
AttributeError: 'list' object has no attribute 'shape'
```
- `RandomFlip3D` is removed. The `RandomFlip3D` stacks all six views of images and change `result["img"]` to a `numpy.ndarray` with shape of (6, 900, 1600, 3), causing problem in following transforms. The traceback would be similar to the following:
```
  File "/mnt/filesystem3/yangyi/anaconda3/envs/re_bevformer/lib/python3.9/site-packages/mmcv/transforms/base.py", line 12, in __call__
    return self.transform(results)
  File "/home/yangyi/wd/git_repo/mmdetection3d/mmdet3d/datasets/transforms/formating.py", line 119, in transform
    return self.pack_single_results(results)
  File "/home/yangyi/wd/git_repo/mmdetection3d/mmdet3d/datasets/transforms/formating.py", line 169, in pack_single_results
    np.ascontiguousarray(img.transpose(2, 0, 1)))
ValueError: axes don't match array
```

With the left transformation `LoadMultiViewImageFromFiles`, `LoadAnnotations3D` and `Pack3DDetInputs`, the pipeline can still finish the basic job of reading multi-view images, loading ground truth and packing.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
