### PR TITLE
[Feature] added indices option for KittiMetric to evaluate on a subset

### DIFF
--- a/mmdet3d/evaluation/metrics/kitti_metric.py
+++ b/mmdet3d/evaluation/metrics/kitti_metric.py
@@ -35,6 +35,8 @@ class KittiMetric(BaseMetric):
         default_cam_key (str): The default camera for lidar to camera
             conversion. By default, KITTI: 'CAM2', Waymo: 'CAM_FRONT'.
             Defaults to 'CAM2'.
+        indices (List[int], optional): Supports only evaluating on a subset of
+            data from the annotation file
         format_only (bool): Format the output results without perform
             evaluation. It is useful when you want to format the result to a
             specific format and submit it to the test server.
@@ -56,6 +58,7 @@ class KittiMetric(BaseMetric):
                  prefix: Optional[str] = None,
                  pklfile_prefix: Optional[str] = None,
                  default_cam_key: str = 'CAM2',
+                 indices: Optional[List[int]] = None,
                  format_only: bool = False,
                  submission_prefix: Optional[str] = None,
                  collect_device: str = 'cpu',
@@ -76,6 +79,7 @@ class KittiMetric(BaseMetric):
         self.submission_prefix = submission_prefix
         self.default_cam_key = default_cam_key
         self.backend_args = backend_args
+        self.indices = indices
 
         allowed_metrics = ['bbox', 'img_bbox', 'mAP', 'LET_mAP']
         self.metrics = metric if isinstance(metric, list) else [metric]
@@ -95,6 +99,8 @@ class KittiMetric(BaseMetric):
             List[dict]: List of Kitti annotations.
         """
         data_annos = data_infos['data_list']
+        if self.indices is not None:
+            data_annos = [data_annos[i] for i in self.indices]
         if not self.format_only:
             cat2label = data_infos['metainfo']['categories']
             label2cat = dict((v, k) for (k, v) in cat2label.items())

--- a/tests/test_evaluation/test_metrics/test_kitti_metric.py
+++ b/tests/test_evaluation/test_metrics/test_kitti_metric.py
@@ -87,3 +87,38 @@ def test_kitti_metric_mAP():
         3.0303030303030307)
     assert np.isclose(ap_dict['pred_instances_3d/KITTI/Overall_3D_AP11_hard'],
                       3.0303030303030307)
+
+
+def test_kitti_metric_indices():
+    if not torch.cuda.is_available():
+        pytest.skip('test requires GPU and torch+cuda')
+    indices = [0, 2]
+    kittimetric = KittiMetric(
+        data_root + '/kitti_infos_train.pkl', metric=['mAP'], indices=indices)
+    kittimetric.dataset_meta = dict(classes=['Pedestrian', 'Cyclist', 'Car'])
+    data_infos = {
+        'data_list': [{
+            'test_id': 0,
+            'instances': []
+        }, {
+            'test_id': 1,
+            'instances': []
+        }, {
+            'test_id': 2,
+            'instances': []
+        }],
+        'metainfo': {
+            'categories': {
+                'Pedestrian': 0,
+                'Cyclist': 1,
+                'Car': 2
+            },
+        }
+    }
+    kitti_annos = kittimetric.convert_annos_to_kitti_annos(data_infos)
+
+    assert len(kitti_annos) == len(indices)
+    assert np.all([
+        indx == kitti_anno['test_id']
+        for indx, kitti_anno in zip(indices, kitti_annos)
+    ])


### PR DESCRIPTION
## Motivation

Evaluating on a subset of the Kitti Dataset

## Modification

- Added indices parameter to KittiMetric and evaluated only using those indices
- Note: I haven't modified any of the other metrics since they seem to be loading data differently and I am not entirely sure whether that feature is required for other dataset
- Note: the corresponding dataloader should be set with the same indices for the code to work as expected

## Use cases (Optional)

Debugging, overfitting on x examples and only using a subset for evaluation in general.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
