### PR TITLE
[Fix] fix bbox_color in Det3DLocalVisualizer

### DIFF
--- a/mmdet3d/visualization/local_visualizer.py
+++ b/mmdet3d/visualization/local_visualizer.py
@@ -312,7 +312,7 @@ class Det3DLocalVisualizer(DetLocalVisualizer):
 
             line_set = geometry.LineSet.create_from_oriented_bounding_box(
                 box3d)
-            line_set.paint_uniform_color(np.array(bbox_color) / 255.)
+            line_set.paint_uniform_color(np.array(bbox_color[i]) / 255.)
             # draw bboxes on visualizer
             self.o3d_vis.add_geometry(line_set)
 
@@ -320,7 +320,7 @@ class Det3DLocalVisualizer(DetLocalVisualizer):
             if self.pcd is not None and mode == 'xyz':
                 indices = box3d.get_point_indices_within_bounding_box(
                     self.pcd.points)
-                self.points_colors[indices] = np.array(bbox_color) / 255.
+                self.points_colors[indices] = np.array(bbox_color[i]) / 255.
 
         # update points colors
         if self.pcd is not None:

--- a/mmdet3d/visualization/local_visualizer.py
+++ b/mmdet3d/visualization/local_visualizer.py
@@ -312,7 +312,7 @@ class Det3DLocalVisualizer(DetLocalVisualizer):
 
             line_set = geometry.LineSet.create_from_oriented_bounding_box(
                 box3d)
-            line_set.paint_uniform_color(np.array(bbox_color[i]) / 255.)
+            line_set.paint_uniform_color(np.array(bbox_color) / 255.)
             # draw bboxes on visualizer
             self.o3d_vis.add_geometry(line_set)
 
@@ -320,7 +320,7 @@ class Det3DLocalVisualizer(DetLocalVisualizer):
             if self.pcd is not None and mode == 'xyz':
                 indices = box3d.get_point_indices_within_bounding_box(
                     self.pcd.points)
-                self.points_colors[indices] = np.array(bbox_color[i]) / 255.
+                self.points_colors[indices] = np.array(bbox_color) / 255.
 
         # update points colors
         if self.pcd is not None:

--- a/mmdet3d/visualization/local_visualizer.py
+++ b/mmdet3d/visualization/local_visualizer.py
@@ -273,7 +273,7 @@ class Det3DLocalVisualizer(DetLocalVisualizer):
         Args:
             bboxes_3d (:obj:`BaseInstance3DBoxes`): 3D bbox
                 (x, y, z, x_size, y_size, z_size, yaw) to visualize.
-            bbox_colors Tuple[float] or List[Tuple[float]]:
+            bbox_colors (Tuple[float] | List[Tuple[float]]):
                 The color of 3D bboxes.
                 Defaults to (0, 1, 0).
             points_in_box_color (Tuple[float]): The color of points inside 3D


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Examples like [this](https://mmdetection3d.readthedocs.io/en/latest/user_guides/visualization.html#drawing-3d-boxes-on-point-cloud) are not working because of a bug. 
Error trace:
```
TypeError: paint_uniform_color(): incompatible function arguments. The following argument types are supported:
    1. (self: open3d.cuda.pybind.geometry.LineSet, color: numpy.ndarray[numpy.float64[3, 1]]) -> open3d.cuda.pybind.geometry.LineSet

Invoked with: LineSet with 12 lines., 0.0
```
## Modification
Add code that determines whether to use a single color for all bounding boxes or force the user to specify a color for each bbox.



## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
