### PR TITLE
[Fix] Fix support for devices other than Cuda in FreeAnchor3DHead

### DIFF
--- a/mmdet3d/models/dense_heads/free_anchor3d_head.py
+++ b/mmdet3d/models/dense_heads/free_anchor3d_head.py
@@ -2,6 +2,7 @@
 from typing import Dict, List
 
 import torch
+from mmengine.device import get_device
 from torch import Tensor
 from torch.nn import functional as F
 
@@ -79,7 +80,9 @@ class FreeAnchor3DHead(Anchor3DHead):
         featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]
         assert len(featmap_sizes) == self.prior_generator.num_levels
 
-        anchor_list = self.get_anchors(featmap_sizes, batch_input_metas)
+        device = get_device()
+        anchor_list = self.get_anchors(featmap_sizes, batch_input_metas,
+                                       device)
         mlvl_anchors = [torch.cat(anchor) for anchor in anchor_list]
 
         # concatenate each level


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix support for devices other than Cuda.

## Modification

The mmdet3d/models/dense_heads/free_anchor3d_head.py file is modified.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
