### PR TITLE
Dev 1.x Adapt PETR to mmcv v2 version dataset 

### DIFF
--- a/projects/PETR/README.md
+++ b/projects/PETR/README.md
@@ -16,7 +16,7 @@ This is an implementation of *PETR*.
 In MMDet3D's root directory, run the following command to train the model:
 
 ```bash
-python tools/train.py projects/PETR/config/petr/petr_vovnet_gridmask_p4_800x320.py
+python tools/train.py projects/PETR/configs/petr_vovnet_gridmask_p4_800x320.py
 ```
 
 ### Testing commands
@@ -24,7 +24,7 @@ python tools/train.py projects/PETR/config/petr/petr_vovnet_gridmask_p4_800x320.
 In MMDet3D's root directory, run the following command to test the model:
 
 ```bash
-python tools/test.py projects/PETR/config/petr/petr_vovnet_gridmask_p4_800x320.py ${CHECKPOINT_PATH}
+python tools/test.py projects/PETR/configs/petr_vovnet_gridmask_p4_800x320.py ${CHECKPOINT_PATH}
 ```
 
 ## Results

--- a/projects/PETR/petr/petr_head.py
+++ b/projects/PETR/petr/petr_head.py
@@ -446,7 +446,7 @@ class PETRHead(AnchorFreeHead):
         masks = x.new_ones((batch_size, num_cams, input_img_h, input_img_w))
         for img_id in range(batch_size):
             for cam_id in range(num_cams):
-                img_h, img_w, _ = img_metas[img_id]['img_shape'][cam_id]
+                img_h, img_w = img_metas[img_id]['img_shape'][cam_id]
                 masks[img_id, cam_id, :img_h, :img_w] = 0
         x = self.input_proj(x.flatten(0, 1))
         x = x.view(batch_size, num_cams, *x.shape[-3:])


### PR DESCRIPTION
## Motivation

I am trying to run PETR project through mmdetction3d, but I found that the implementation is obsoleted

## Modification

I updated the document of PETR project to quickly run a training and testing script.

And I updated the PETR head to adapt to the v2 dataset format.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
