### PR TITLE
Replace np.long with np.int64

### DIFF
--- a/mmdet3d/datasets/transforms/dbsampler.py
+++ b/mmdet3d/datasets/transforms/dbsampler.py
@@ -280,7 +280,7 @@ class DataBaseSampler(object):
                 s_points_list.append(s_points)
 
             gt_labels = np.array([self.cat2label[s['name']] for s in sampled],
-                                 dtype=np.long)
+                                 dtype=np.int64)
 
             if ground_plane is not None:
                 xyz = sampled_gt_bboxes[:, :3]


### PR DESCRIPTION
## Motivation

This is a small PR to replace np.long. It has obviously already been done in most places in https://github.com/open-mmlab/mmdetection3d/pull/1270 and should silence warnings from numpy as np.long is deprecated since numpy version 1.20 (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

## Modification

Replace the last occurrence of np.long by np.int64.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

No breaking changes, just a minor fix.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
