### PR TITLE
Centerpoint bbox coders: Fix torch warning

### DIFF
--- a/mmdet3d/models/task_modules/coders/centerpoint_bbox_coders.py
+++ b/mmdet3d/models/task_modules/coders/centerpoint_bbox_coders.py
@@ -36,7 +36,7 @@ class CenterPointBBoxCoder(BaseBBoxCoder):
         self.pc_range = pc_range
         self.out_size_factor = out_size_factor
         self.voxel_size = voxel_size
-        self.post_center_range = post_center_range
+        self.post_center_range = Tensor(post_center_range)
         self.max_num = max_num
         self.score_threshold = score_threshold
         self.code_size = code_size
@@ -204,8 +204,8 @@ class CenterPointBBoxCoder(BaseBBoxCoder):
             thresh_mask = final_scores > self.score_threshold
 
         if self.post_center_range is not None:
-            self.post_center_range = torch.tensor(
-                self.post_center_range, device=heat.device)
+            self.post_center_range = self.post_center_range.to(
+                device=heat.device)
             mask = (final_box_preds[..., :3] >=
                     self.post_center_range[:3]).all(2)
             mask &= (final_box_preds[..., :3] <=

--- a/mmdet3d/models/task_modules/coders/centerpoint_bbox_coders.py
+++ b/mmdet3d/models/task_modules/coders/centerpoint_bbox_coders.py
@@ -127,7 +127,7 @@ class CenterPointBBoxCoder(BaseBBoxCoder):
                rot_cosine: Tensor,
                hei: Tensor,
                dim: Tensor,
-               vel: Tensor,
+               vel: Optional[Tensor],
                reg: Optional[Tensor] = None,
                task_id: int = -1) -> List[Dict[str, Tensor]]:
         """Decode bboxes.
@@ -141,8 +141,8 @@ class CenterPointBBoxCoder(BaseBBoxCoder):
             hei (torch.Tensor): Height of the boxes with the shape
                 of [B, 1, W, H].
             dim (torch.Tensor): Dim of the boxes with the shape of
-                [B, 1, W, H].
-            vel (torch.Tensor): Velocity with the shape of [B, 1, W, H].
+                [B, 3, W, H].
+            vel (torch.Tensor): Velocity with the shape of [B, 2, W, H].
             reg (torch.Tensor, optional): Regression value of the boxes in
                 2D with the shape of [B, 2, W, H]. Default: None.
             task_id (int, optional): Index of task. Default: -1.

--- a/mmdet3d/models/task_modules/coders/centerpoint_bbox_coders.py
+++ b/mmdet3d/models/task_modules/coders/centerpoint_bbox_coders.py
@@ -36,7 +36,8 @@ class CenterPointBBoxCoder(BaseBBoxCoder):
         self.pc_range = pc_range
         self.out_size_factor = out_size_factor
         self.voxel_size = voxel_size
-        self.post_center_range = Tensor(post_center_range)
+        self.post_center_range = Tensor(
+            post_center_range) if post_center_range is not None else None
         self.max_num = max_num
         self.score_threshold = score_threshold
         self.code_size = code_size


### PR DESCRIPTION
## Motivation

I currently get the following warning from the centerpoints bbox coder:
```
mmdet3d/models/task_modules/coders/centerpoint_bbox_coders.py:207: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  self.post_center_range = torch.tensor(
```
The reason is that `self.post_center_range` is already a `torch.Tensor` after the first call of decode and then `torch.Tensor` is called on a Tensor in every following call. 

## Modification

Create `self.post_center_range` as Tensor in the initialization of `CenterPointBBoxCoder` and only make sure that it is on the right device when `decode` is called.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
No breaking/functionally relevant changes

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
