### PR TITLE
Update mono_det3d_inferencer.py

### DIFF
--- a/mmdet3d/apis/inferencers/mono_det3d_inferencer.py
+++ b/mmdet3d/apis/inferencers/mono_det3d_inferencer.py
@@ -114,18 +114,19 @@ class MonoDet3DInferencer(Base3DInferencer):
                         f'the info file of {img_path} is not provided.')
                 cam2img = np.asarray(
                     data_info['images'][cam_type]['cam2img'], dtype=np.float32)
-                lidar2cam = np.asarray(
-                    data_info['images'][cam_type]['lidar2cam'],
-                    dtype=np.float32)
-                if 'lidar2img' in data_info['images'][cam_type]:
-                    lidar2img = np.asarray(
-                        data_info['images'][cam_type]['lidar2img'],
+                if 'lidar2cam' in data_info['images'][cam_type]:
+                    lidar2cam = np.asarray(
+                        data_info['images'][cam_type]['lidar2cam'],
                         dtype=np.float32)
-                else:
-                    lidar2img = cam2img @ lidar2cam
+                    if 'lidar2img' in data_info['images'][cam_type]:
+                        lidar2img = np.asarray(
+                            data_info['images'][cam_type]['lidar2img'],
+                            dtype=np.float32)
+                    else:
+                        lidar2img = cam2img @ lidar2cam
+                    input['lidar2cam'] = lidar2cam
+                    input['lidar2img'] = lidar2img
                 input['cam2img'] = cam2img
-                input['lidar2cam'] = lidar2cam
-                input['lidar2img'] = lidar2img
         elif isinstance(inputs, (list, tuple)):
             # get cam2img, lidar2cam and lidar2img from infos
             for input in inputs:
@@ -142,18 +143,20 @@ class MonoDet3DInferencer(Base3DInferencer):
                         f'the info file of {img_path} is not provided.')
                 cam2img = np.asarray(
                     data_info['images'][cam_type]['cam2img'], dtype=np.float32)
-                lidar2cam = np.asarray(
-                    data_info['images'][cam_type]['lidar2cam'],
-                    dtype=np.float32)
-                if 'lidar2img' in data_info['images'][cam_type]:
-                    lidar2img = np.asarray(
-                        data_info['images'][cam_type]['lidar2img'],
+                if 'lidar2cam' in data_info['images'][cam_type]:
+                    lidar2cam = np.asarray(
+                        data_info['images'][cam_type]['lidar2cam'],
                         dtype=np.float32)
-                else:
-                    lidar2img = cam2img @ lidar2cam
+                    if 'lidar2img' in data_info['images'][cam_type]:
+                        lidar2img = np.asarray(
+                            data_info['images'][cam_type]['lidar2img'],
+                            dtype=np.float32)
+                    else:
+                        lidar2img = cam2img @ lidar2cam
+
+                    input['lidar2cam'] = lidar2cam
+                    input['lidar2img'] = lidar2img
                 input['cam2img'] = cam2img
-                input['lidar2cam'] = lidar2cam
-                input['lidar2img'] = lidar2img
 
         return list(inputs)
 


### PR DESCRIPTION
remove dependancy to lidar for mono det3D inferencer

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

For mono detection the inferencer should not have dependancy to lidar2cam and lidar2img matrices. But in the current version it loads them as np.asarrays. So if one is using a dataset(public/custom) that does not have lidar sensor, they won't be able to use the inference module. Moreover the networks don't even use those two matrices, making it completely unnecessary to load them in the code.

## Modification

added conditions to only load lidar transitions matrices if they are in the annotation data.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
