### PR TITLE
Fix for BEVFusion HungarianAssigner3D 

### DIFF
--- a/mmdet3d/datasets/transforms/dbsampler.py
+++ b/mmdet3d/datasets/transforms/dbsampler.py
@@ -280,7 +280,7 @@ class DataBaseSampler(object):
                 s_points_list.append(s_points)
 
             gt_labels = np.array([self.cat2label[s['name']] for s in sampled],
-                                 dtype=np.long)
+                                 dtype=np.int64)
 
             if ground_plane is not None:
                 xyz = sampled_gt_bboxes[:, :3]

--- a/projects/BEVFusion/bevfusion/utils.py
+++ b/projects/BEVFusion/bevfusion/utils.py
@@ -271,8 +271,15 @@ class HungarianAssigner3D(BaseAssigner):
             if num_gts == 0:
                 # No ground truth, assign all to background
                 assigned_gt_inds[:] = 0
+            max_overlaps = torch.zeros(
+                max(num_gts, num_bboxes),
+                device=bboxes.device,
+                dtype=torch.float32)
             return AssignResult(
-                num_gts, assigned_gt_inds, None, labels=assigned_labels)
+                num_gts,
+                assigned_gt_inds,
+                max_overlaps,
+                labels=assigned_labels)
 
         # 2. compute the weighted costs
         # Hard code here to be compatible with the interface of


### PR DESCRIPTION
## Motivation

In case of no ground truth, the HungarianAssigner3D in the BEVFusion project returns 'None' instead of a tensor. 
This will rise an error in the following code of the transfusion_head.py running:
max_overlaps=torch.cat([res.max_overlaps for res in assign_result_list]), 

## Modification

return a tensor with zeros for max_overlaps if there is no ground truth or no bounding boxes. In case both are 0, an empty tensor is returned which still provides better compatibility

## Use cases (Optional)

no error in cases where no ground truth or no bounding box is given.

