### PR TITLE
Fix PETR transforms and box handling to work with old checkpoints

### DIFF
--- a/projects/PETR/petr/transforms_3d.py
+++ b/projects/PETR/petr/transforms_3d.py
@@ -175,35 +175,33 @@ class GlobalRotScaleTransImage(BaseTransform):
         return results
 
     def rotate_bev_along_z(self, results, angle):
-        rot_cos = torch.cos(torch.tensor(angle))
-        rot_sin = torch.sin(torch.tensor(angle))
+        rot_cos = np.cos(angle)
+        rot_sin = np.sin(angle)
 
-        rot_mat = torch.tensor([[rot_cos, -rot_sin, 0, 0],
-                                [rot_sin, rot_cos, 0, 0], [0, 0, 1, 0],
-                                [0, 0, 0, 1]])
-        rot_mat_inv = torch.inverse(rot_mat)
+        rot_mat = np.array([[rot_cos, rot_sin, 0, 0],
+                            [-rot_sin, rot_cos, 0, 0], [0, 0, 1, 0],
+                            [0, 0, 0, 1]])
+        rot_mat_inv = np.linalg.inverse(rot_mat)
         num_view = len(results['lidar2cam'])
         for view in range(num_view):
             results['lidar2cam'][view] = (
-                torch.tensor(np.array(results['lidar2cam'][view]).T).float()
-                @ rot_mat_inv).T.numpy()
+                results['lidar2cam'][view] @ rot_mat_inv)
 
         return
 
     def scale_xyz(self, results, scale_ratio):
-        rot_mat = torch.tensor([
+        scale_mat = np.array([
             [scale_ratio, 0, 0, 0],
             [0, scale_ratio, 0, 0],
             [0, 0, scale_ratio, 0],
             [0, 0, 0, 1],
         ])
 
-        rot_mat_inv = torch.inverse(rot_mat)
+        scale_mat_inv = np.linalg.inverse(scale_mat)
 
         num_view = len(results['lidar2cam'])
         for view in range(num_view):
-            results['lidar2cam'][view] = (torch.tensor(
-                rot_mat_inv.T
-                @ results['lidar2cam'][view].T).float()).T.numpy()
+            results['lidar2cam'][view] = (
+                scale_mat_inv @ results['lidar2cam'][view])
 
         return

--- a/projects/PETR/petr/utils.py
+++ b/projects/PETR/petr/utils.py
@@ -14,17 +14,19 @@ def normalize_bbox(bboxes, pc_range):
     width = bboxes[..., 4:5].log()
     height = bboxes[..., 5:6].log()
 
+    # normalize boxes to match the old checkpoints trained prior to
+    # coordinate system refactoring (<v1.0.0)
     rot = -bboxes[..., 6:7] - np.pi / 2
     rot = limit_period(rot, period=np.pi * 2)
     if bboxes.size(-1) > 7:
         vx = bboxes[..., 7:8]
         vy = bboxes[..., 8:9]
         normalized_bboxes = torch.cat(
-            (cx, cy, length, width, cz, height, rot.sin(), rot.cos(), vx, vy),
+            (cx, cy, width, length, cz, height, rot.sin(), rot.cos(), vx, vy),
             dim=-1)
     else:
         normalized_bboxes = torch.cat(
-            (cx, cy, length, width, cz, height, rot.sin(), rot.cos()), dim=-1)
+            (cx, cy, width, length, cz, height, rot.sin(), rot.cos()), dim=-1)
     return normalized_bboxes
 
 
@@ -42,9 +44,11 @@ def denormalize_bbox(normalized_bboxes, pc_range):
     cy = normalized_bboxes[..., 1:2]
     cz = normalized_bboxes[..., 4:5]
 
+    # boxes are expected to match the format from old checkpoints,
+    # denormalize them to match the new format
     # size
-    length = normalized_bboxes[..., 2:3]
-    width = normalized_bboxes[..., 3:4]
+    width = normalized_bboxes[..., 2:3]
+    length = normalized_bboxes[..., 3:4]
     height = normalized_bboxes[..., 5:6]
 
     width = width.exp()


### PR DESCRIPTION
## Motivation

Current version of the PETR-project does not produce the reported metrics (see https://github.com/open-mmlab/mmdetection3d/issues/2510 for more details). The current state of the project has the following issues:
- Incorrect rotation and scaling of the camera pose when doing 3D transforms.
- Incorrect normalizing (and denormalizing) of bounding boxes. Current normalizing is not compatible with the checkpoint in the repo, effectively switching length and width, causing large scale errors.

## Modification

This PR fixes:
- The 3D transforms to work correctly with versions >v1.0.0 (i.e after the coordinate system refactoring).
- The normalizing (and denormalizing) of boxes to work with the old checkpoint.

Results from testing the PR on nuScenes validation set (with the old checkpoint):
```
mAP: 0.3829
mATE: 0.7376
mASE: 0.2702
mAOE: 0.4803
mAVE: 0.8703
mAAE: 0.2040
NDS: 0.4352
```
Log from the test: [20240305_103838.log](https://github.com/open-mmlab/mmdetection3d/files/14494020/20240305_103838.log)