### PR TITLE
Fix rstrip bug in publish_model.py

### DIFF
--- a/tools/model_converters/publish_model.py
+++ b/tools/model_converters/publish_model.py
@@ -23,7 +23,7 @@ def process_checkpoint(in_file, out_file):
     # add the code here.
     torch.save(checkpoint, out_file)
     sha = subprocess.check_output(['sha256sum', out_file]).decode()
-    final_file = out_file.rstrip('.pth') + '-{}.pth'.format(sha[:8])
+    final_file = out_file.removesuffix('.pth') + '-{}.pth'.format(sha[:8])
     subprocess.Popen(['mv', out_file, final_file])
 
 


### PR DESCRIPTION
## Motivation

`.rstrip(".pth")` will convert `pthhtp.pth` to the empty string.  This is a bug.

`removesuffix` does the right thing, but works only from Python 3.10 up.

## Modification

`rstrip` -> `removesuffix`

## BC-breaking (Optional)

Only works with Python 3.10+.

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
