### PR TITLE
Suport  train/test bevfusion with waymo dataset.

### DIFF
--- a/projects/BEVFusion/bevfusion/loading.py
+++ b/projects/BEVFusion/bevfusion/loading.py
@@ -147,7 +147,7 @@ class BEVLoadMultiViewImageFromFiles(LoadMultiViewImageFromFiles):
 
             cam2img_array = np.eye(4).astype(np.float32)
             cam2img_array[:3, :3] = np.array(cam_item['cam2img']).astype(
-                np.float32)
+                np.float32)[:3,:3]
             cam2img.append(cam2img_array)
             lidar2img.append(cam2img_array @ lidar2cam_array)
 


### PR DESCRIPTION
## Motivation

When I train/test bevfusion with waymo dataset, some errors occurred, you can see it in ## Modification.

## Modification

1. Compatible with varying image sizes from multiple viewpoints in Det3DLocalVisualizer.
2. Compatible with camera intrinsic parameters in the 3x4 format(e.g. waymo), in BEVLoadMultiViewImageFromFiles.


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
