### PR TITLE
[Fix] fix wrong coordinate transform in sweep loading

### DIFF
--- a/mmdet3d/datasets/transforms/loading.py
+++ b/mmdet3d/datasets/transforms/loading.py
@@ -440,9 +440,10 @@ class LoadPointsFromMultiSweeps(BaseTransform):
                 # bc-breaking: Timestamp has divided 1e6 in pkl infos.
                 sweep_ts = sweep['timestamp']
                 lidar2sensor = np.array(sweep['lidar_points']['lidar2sensor'])
+                #Perform inverse transform 
+                points_sweep[:, :3] -= lidar2sensor[:3, 3]
                 points_sweep[:, :
                              3] = points_sweep[:, :3] @ lidar2sensor[:3, :3]
-                points_sweep[:, :3] -= lidar2sensor[:3, 3]
                 points_sweep[:, 4] = ts - sweep_ts
                 points_sweep = points.new_point(points_sweep)
                 sweep_points_list.append(points_sweep)


### PR DESCRIPTION
## Motivation

Fix wrong coordinate transform in sweep loading， the wrong transform caused bad input for model, especially when rotation is large

## Modification

the sensor to lidar transform is
Y = X @ Rt + T

so the reverse transform should be:

X= (Y - T) @ R 