### PR TITLE
[Fix] Problem of failing to save images after open3d visualization

### DIFF
--- a/mmdet3d/datasets/transforms/dbsampler.py
+++ b/mmdet3d/datasets/transforms/dbsampler.py
@@ -280,7 +280,7 @@ class DataBaseSampler(object):
                 s_points_list.append(s_points)
 
             gt_labels = np.array([self.cat2label[s['name']] for s in sampled],
-                                 dtype=np.long)
+                                 dtype=np.int64)
 
             if ground_plane is not None:
                 xyz = sampled_gt_bboxes[:, :3]

--- a/mmdet3d/visualization/local_visualizer.py
+++ b/mmdet3d/visualization/local_visualizer.py
@@ -884,7 +884,7 @@ class Det3DLocalVisualizer(DetLocalVisualizer):
                     self.view_port = \
                         self.view_control.convert_to_pinhole_camera_parameters()  # noqa: E501
                 self.flag_next = False
-            self.o3d_vis.clear_geometries()
+            # self.o3d_vis.clear_geometries()
             try:
                 del self.pcd
             except (KeyError, AttributeError):
@@ -893,7 +893,7 @@ class Det3DLocalVisualizer(DetLocalVisualizer):
                 if not (save_path.endswith('.png')
                         or save_path.endswith('.jpg')):
                     save_path += '.png'
-                self.o3d_vis.capture_screen_image(save_path)
+                self.o3d_vis.capture_screen_image(save_path, do_render=True)
             if self.flag_exit:
                 self.o3d_vis.destroy_window()
                 self.o3d_vis.close()


### PR DESCRIPTION
## Motivation

While verifying the inference demo according to the following code in [Get Started](https://mmdetection3d.readthedocs.io/en/latest/get_started.html),  we often find that the open3d library can visualize the point cloud and detection results, but after closing the visualization window, the results are not saved to the image (the image is often completely black). To fix this issue we raised this PR.

Code:
```
python demo/pcd_demo.py demo/data/kitti/000008.bin pointpillars_hv_secfpn_8xb6-160e_kitti-3d-car.py hv_pointpillars_secfpn_6x8_160e_kitti-3d-car_20220331_134606-d42d15ed.pth --show
```

Visualize window:
![image](https://github.com/user-attachments/assets/789c03cc-7918-426a-96c6-68b6418c32a5)

Saved image (before modification):
![image](https://github.com/user-attachments/assets/6e3bb355-c29a-41cf-8352-2cf9e3f541e3)

## Modification

We modify the `show()` function in the mmdet3d/visualization/local_visualizer.py file.

1. We annotate `self.o3d_vis.clear_geometries()` in line 887, because geometries should not be cleared before saving as an image.
2. We modify `self.o3d_vis.capture_screen_image(save_path)` in line 896 to  `self.o3d_vis.capture_screen_image(save_path, do_render=True)`,  because we need to re-render after manually closing the visualization window to ensure that the stored image is not empty.

After our modification, the visualization results can be saved to the image normally.

Saved image (after modification):
![image](https://github.com/user-attachments/assets/1c5de9b6-af81-4e08-8267-be7521a9152e)

