### PR TITLE
[Fix] Replace hardcoded .cuda() with device-aware .to() in MinkUNet voxelization

### DIFF
--- a/mmdet3d/models/data_preprocessors/data_preprocessor.py
+++ b/mmdet3d/models/data_preprocessors/data_preprocessor.py
@@ -434,12 +434,12 @@ class Det3DDataPreprocessor(DetDataPreprocessor):
                 res_coors_numpy = res_coors.cpu().numpy()
                 inds, point2voxel_map = self.sparse_quantize(
                     res_coors_numpy, return_index=True, return_inverse=True)
-                point2voxel_map = torch.from_numpy(point2voxel_map).cuda()
+                point2voxel_map = torch.from_numpy(point2voxel_map).to(res.device)
                 if self.training and self.max_voxels is not None:
                     if len(inds) > self.max_voxels:
                         inds = np.random.choice(
                             inds, self.max_voxels, replace=False)
-                inds = torch.from_numpy(inds).cuda()
+                inds = torch.from_numpy(inds).to(res.device)
                 if hasattr(data_sample.gt_pts_seg, 'pts_semantic_mask'):
                     data_sample.gt_pts_seg.voxel_semantic_mask \
                         = data_sample.gt_pts_seg.pts_semantic_mask[inds]

--- a/mmdet3d/models/data_preprocessors/data_preprocessor.py
+++ b/mmdet3d/models/data_preprocessors/data_preprocessor.py
@@ -434,7 +434,8 @@ class Det3DDataPreprocessor(DetDataPreprocessor):
                 res_coors_numpy = res_coors.cpu().numpy()
                 inds, point2voxel_map = self.sparse_quantize(
                     res_coors_numpy, return_index=True, return_inverse=True)
-                point2voxel_map = torch.from_numpy(point2voxel_map).to(res.device)
+                point2voxel_map = torch.from_numpy(point2voxel_map).to(
+                    res.device)
                 if self.training and self.max_voxels is not None:
                     if len(inds) > self.max_voxels:
                         inds = np.random.choice(


### PR DESCRIPTION
## Motivation

In `Det3DDataPreprocessor.voxelize()`, the `minkunet` voxelization branch converts numpy arrays back to tensors using `torch.from_numpy(...).cuda()`. This hardcodes the CUDA device assumption, which causes:

1. **RuntimeError on CPU-only environments** — users without a GPU cannot use MinkUNet-based models at all
2. **Incorrect device placement in multi-GPU setups** — tensors always land on `cuda:0` regardless of which device the input data resides on (e.g., `cuda:1`), leading to device mismatch errors during subsequent operations

## Modification

Replace `.cuda()` with `.to(res.device)` for both `point2voxel_map` and `inds` tensors, where `res` is the input point cloud tensor already on the correct device. This is consistent with how device handling is done elsewhere in the same file (e.g., using `.new_tensor()` and `F.pad()` which inherit the device from existing tensors).

**Before:**
```python
point2voxel_map = torch.from_numpy(point2voxel_map).cuda()
...
inds = torch.from_numpy(inds).cuda()
```

**After:**
```python
point2voxel_map = torch.from_numpy(point2voxel_map).to(res.device)
...
inds = torch.from_numpy(inds).to(res.device)
```

## BC-breaking (No)

This is a backward-compatible fix. On CUDA environments, `res.device` will be `cuda:X` (matching the previous behavior when on `cuda:0`), and it additionally supports CPU and multi-GPU scenarios correctly.