### PR TITLE
[Fix] Avoid empty splits in KITTI evaluation

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: Build and install
           command: |
-            pip install --no-build-isolation -e .
+            python setup.py develop
       - run:
           name: Run unittests
           command: |
@@ -124,7 +124,7 @@ jobs:
       - run:
           name: Build and install
           command: |
-            docker exec mmdet3d pip install --no-build-isolation -e .
+            docker exec mmdet3d python setup.py develop
       - run:
           name: Run unittests
           command: |

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -66,7 +66,7 @@ jobs:
             pip install 'mmengine >= 0.8.0, < 1.0.0'
             pip install -U openmim
             mim install 'mmcv >= 2.0.0rc4, < 2.2.0'
-            pip install git+ssh://git@github.com/open-mmlab/mmdetection.git@dev-3.x
+            pip install --no-build-isolation git+ssh://git@github.com/open-mmlab/mmdetection.git@dev-3.x
             pip install -r requirements/tests.txt
       - run:
           name: Build and install

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Install mmdet3d dependencies
           command: |
-            pip install git+ssh://git@github.com/open-mmlab/mmengine.git@main
+            pip install 'mmengine >= 0.8.0, < 1.0.0'
             pip install -U openmim
             mim install 'mmcv >= 2.0.0rc4, < 2.2.0'
             pip install git+ssh://git@github.com/open-mmlab/mmdetection.git@dev-3.x
@@ -154,7 +154,7 @@ workflows:
           name: minimum_version_cpu
           torch: 1.8.1
           torchvision: 0.9.1
-          python: 3.8.16
+          python: 3.7.4 # The lowest python 3.7.x version available on CircleCI images
           requires:
             - lint
       - build_cpu:

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             pip install git+ssh://git@github.com/open-mmlab/mmengine.git@main
             pip install -U openmim
-            mim install 'mmcv >= 2.0.0rc4'
+            mim install 'mmcv >= 2.0.0rc4, < 2.2.0'
             pip install git+ssh://git@github.com/open-mmlab/mmdetection.git@dev-3.x
             pip install -r requirements/tests.txt
       - run:

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -154,7 +154,7 @@ workflows:
           name: minimum_version_cpu
           torch: 1.8.1
           torchvision: 0.9.1
-          python: 3.7.4 # The lowest python 3.7.x version available on CircleCI images
+          python: 3.8.16
           requires:
             - lint
       - build_cpu:

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -67,7 +67,7 @@ jobs:
             pip install -U openmim
             mim install 'mmcv >= 2.0.0rc4, < 2.2.0'
             pip install --no-build-isolation git+ssh://git@github.com/open-mmlab/mmdetection.git@dev-3.x
-            pip install -r requirements/tests.txt
+            pip install -r requirements/runtime.txt -r requirements/tests.txt
       - run:
           name: Build and install
           command: |
@@ -120,7 +120,7 @@ jobs:
             docker exec mmdet3d pip install -U openmim
             docker exec mmdet3d mim install 'mmcv >= 2.0.0rc4'
             docker exec mmdet3d pip install -e /mmdetection
-            docker exec mmdet3d pip install -r requirements/tests.txt
+            docker exec mmdet3d pip install -r requirements/runtime.txt -r requirements/tests.txt
       - run:
           name: Build and install
           command: |

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: Build and install
           command: |
-            python setup.py develop
+            python setup.py develop --no-deps
       - run:
           name: Run unittests
           command: |
@@ -124,7 +124,7 @@ jobs:
       - run:
           name: Build and install
           command: |
-            docker exec mmdet3d python setup.py develop
+            docker exec mmdet3d python setup.py develop --no-deps
       - run:
           name: Run unittests
           command: |

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: Build and install
           command: |
-            pip install -e .
+            pip install --no-build-isolation -e .
       - run:
           name: Run unittests
           command: |
@@ -124,7 +124,7 @@ jobs:
       - run:
           name: Build and install
           command: |
-            docker exec mmdet3d pip install -e .
+            docker exec mmdet3d pip install --no-build-isolation -e .
       - run:
           name: Run unittests
           command: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: docs/en/conf.py
+
 build:
   os: ubuntu-22.04
   tools:

--- a/mmdet3d/evaluation/functional/kitti_utils/eval.py
+++ b/mmdet3d/evaluation/functional/kitti_utils/eval.py
@@ -285,10 +285,13 @@ def get_split_parts(num, num_part):
     if num % num_part == 0:
         same_part = num // num_part
         return [same_part] * num_part
-    else:
-        same_part = num // (num_part - 1)
-        remain_num = num % (num_part - 1)
-        return [same_part] * (num_part - 1) + [remain_num]
+
+    same_part = num // (num_part - 1)
+    remain_num = num % (num_part - 1)
+    split_parts = [same_part] * (num_part - 1)
+    if remain_num:
+        split_parts.append(remain_num)
+    return split_parts
 
 
 @numba.jit(nopython=True)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,7 @@ isort
 # Note: used for kwarray.group_items, this may be ported to mmcv in the future.
 kwarray
 parameterized
-pytest
+pytest<8
 pytest-cov
 pytest-runner
 ubelt

--- a/tests/test_evaluation/test_functional/test_kitti_eval.py
+++ b/tests/test_evaluation/test_functional/test_kitti_eval.py
@@ -4,6 +4,22 @@ import pytest
 import torch
 
 from mmdet3d.evaluation import do_eval, eval_class, kitti_eval
+from mmdet3d.evaluation.functional.kitti_utils.eval import calculate_iou_partly
+
+
+def test_calculate_iou_partly_without_empty_split():
+    annotation = dict(
+        name=np.array(['Car']),
+        bbox=np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float64))
+    annotations = [annotation] * 995
+
+    overlaps, parted_overlaps, total_dt_num, total_gt_num = \
+        calculate_iou_partly(annotations, annotations, metric=0, num_parts=200)
+
+    assert len(overlaps) == 995
+    assert len(parted_overlaps) == 199
+    assert np.all(total_dt_num == 1)
+    assert np.all(total_gt_num == 1)
 
 
 def test_do_eval():


### PR DESCRIPTION
## Motivation

`get_split_parts(995, 200)` currently returns 199 parts of size 5 followed by a zero-sized part. `calculate_iou_partly` then slices an empty annotation batch and calls `np.concatenate` with no arrays, raising `ValueError: need at least one array to concatenate` during KITTI evaluation.

Fixes #3090.

## Modification

- Append the remainder split only when it contains examples, preserving the existing split strategy and the requested maximum part count.
- Add a regression test that runs the reported 995-example case through `calculate_iou_partly` and verifies that all examples and box counts are preserved.

## BC-breaking

No. The change only removes a zero-sized internal split that could not be evaluated successfully.

## Test plan

- `pre-commit run --files mmdet3d/evaluation/functional/kitti_utils/eval.py tests/test_evaluation/test_functional/test_kitti_eval.py` (passed)
- Python 3.10 before/after reproduction through `calculate_iou_partly` with 995 annotations and 200 parts (passed after the fix; reproduced the reported exception before it)
- Partition invariant sweep over 380,100 valid `(num, num_parts)` combinations, checking positive parts, preserved totals, and the part-count limit (passed)

## Checklist

1. Pre-commit and lint checks pass for the modified files.
2. The modification is covered by a regression test.
3. The change does not affect downstream APIs.
4. No documentation update is required for this internal correctness fix.