### PR TITLE
Feat/pandaset support

### DIFF
--- a/configs/_base_/datasets/pandaset-3d.py
+++ b/configs/_base_/datasets/pandaset-3d.py
@@ -1,6 +1,7 @@
 # PandaSet dataset settings for 3D object detection
 # PandaSet features dual LiDAR (Pandar64 + PandarGT) in world coordinates.
-# Points are transformed to ego-centric frame on-the-fly by LoadPointsFromPandaSet.
+# Points are transformed to ego-centric frame on-the-fly
+# by LoadPointsFromPandaSet.
 point_cloud_range = [-50, -50, -5, 50, 50, 3]
 
 # Use the same 10 classes as nuScenes for cross-dataset evaluation

--- a/configs/_base_/datasets/pandaset-3d.py
+++ b/configs/_base_/datasets/pandaset-3d.py
@@ -1,0 +1,45 @@
+# PandaSet dataset settings for 3D object detection
+# PandaSet features dual LiDAR (Pandar64 + PandarGT) in world coordinates.
+# Points are transformed to ego-centric frame on-the-fly by LoadPointsFromPandaSet.
+point_cloud_range = [-50, -50, -5, 50, 50, 3]
+
+# Use the same 10 classes as nuScenes for cross-dataset evaluation
+class_names = [
+    'car', 'truck', 'trailer', 'bus', 'construction_vehicle', 'bicycle',
+    'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'
+]
+metainfo = dict(classes=class_names)
+dataset_type = 'PandaSetDataset'
+data_root = 'data/pandaset/'
+input_modality = dict(use_lidar=True, use_camera=False)
+
+test_pipeline = [
+    dict(type='LoadPointsFromPandaSet', coord_type='LIDAR', use_dim=4),
+    dict(type='Pack3DDetInputs', keys=['points']),
+]
+
+test_dataloader = dict(
+    batch_size=4,
+    num_workers=4,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file='pandaset_pandar64_infos_test.pkl',
+        data_prefix=dict(pts=''),
+        pipeline=test_pipeline,
+        modality=input_modality,
+        test_mode=True,
+        metainfo=metainfo,
+        box_type_3d='LiDAR'))
+
+test_evaluator = dict(
+    type='PandaSetMetric',
+    ann_file=data_root + 'pandaset_pandar64_infos_test.pkl')
+test_cfg = dict()
+
+val_dataloader = test_dataloader
+val_cfg = dict()
+val_evaluator = test_evaluator

--- a/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py
+++ b/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py
@@ -1,0 +1,55 @@
+"""PointPillars nuScenes-trained model evaluated on PandaSet (cross-dataset).
+
+Uses LoadPointsFromPandaSet to read original PandaSet .pkl files on-the-fly,
+avoiding the need to pre-convert ~22 GB of point cloud data to .bin format.
+
+Config for Pandar64 (360 degree lidar). For PandarGT, use the pandargt config.
+"""
+
+_base_ = [
+    '../_base_/models/pointpillars_hv_fpn_nus.py',
+    '../_base_/default_runtime.py',
+]
+
+# ── Dataset settings ─────────────────────────────────────────────────────────
+data_root = 'data/datasets/pandaset/'
+ann_file = 'pkls/pandaset_pandar64_infos_test.pkl'
+
+class_names = [
+    'car', 'truck', 'trailer', 'bus', 'construction_vehicle',
+    'bicycle', 'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'
+]
+point_cloud_range = [-50, -50, -5, 50, 50, 3]
+input_modality = dict(use_lidar=True, use_camera=False)
+metainfo = dict(classes=class_names)
+
+test_pipeline = [
+    dict(type='LoadPointsFromPandaSet', coord_type='LIDAR', use_dim=4),
+    dict(type='Pack3DDetInputs', keys=['points']),
+]
+
+test_dataloader = dict(
+    batch_size=4,
+    num_workers=4,
+    persistent_workers=True,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
+        type='PandaSetDataset',
+        data_root=data_root,
+        ann_file=ann_file,
+        data_prefix=dict(pts=''),
+        pipeline=test_pipeline,
+        modality=input_modality,
+        test_mode=True,
+        metainfo=metainfo,
+        box_type_3d='LiDAR'))
+
+test_evaluator = dict(
+    type='PandaSetMetric',
+    ann_file=data_root + ann_file)
+test_cfg = dict()
+
+val_dataloader = test_dataloader
+val_cfg = dict()
+val_evaluator = test_evaluator

--- a/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py
+++ b/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py
@@ -12,8 +12,8 @@ _base_ = [
 ]
 
 # ── Dataset settings ─────────────────────────────────────────────────────────
-data_root = 'data/datasets/pandaset/'
-ann_file = 'pkls/pandaset_pandar64_infos_test.pkl'
+data_root = 'data/pandaset/'
+ann_file = 'pandaset_pandar64_infos_test.pkl'
 
 class_names = [
     'car', 'truck', 'trailer', 'bus', 'construction_vehicle',

--- a/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py
+++ b/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py
@@ -16,8 +16,8 @@ data_root = 'data/pandaset/'
 ann_file = 'pandaset_pandar64_infos_test.pkl'
 
 class_names = [
-    'car', 'truck', 'trailer', 'bus', 'construction_vehicle',
-    'bicycle', 'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'
+    'car', 'truck', 'trailer', 'bus', 'construction_vehicle', 'bicycle',
+    'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'
 ]
 point_cloud_range = [-50, -50, -5, 50, 50, 3]
 input_modality = dict(use_lidar=True, use_camera=False)
@@ -45,9 +45,7 @@ test_dataloader = dict(
         metainfo=metainfo,
         box_type_3d='LiDAR'))
 
-test_evaluator = dict(
-    type='PandaSetMetric',
-    ann_file=data_root + ann_file)
+test_evaluator = dict(type='PandaSetMetric', ann_file=data_root + ann_file)
 test_cfg = dict()
 
 val_dataloader = test_dataloader

--- a/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-pandargt-eval.py
+++ b/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-pandargt-eval.py
@@ -1,4 +1,7 @@
-"""PointPillars nuScenes-trained model evaluated on PandaSet PandarGT (forward-facing)."""
+"""PointPillars nuScenes-trained model evaluated on PandaSet PandarGT.
+
+Forward-facing LiDAR evaluation config.
+"""
 
 _base_ = ['./pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py']
 

--- a/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-pandargt-eval.py
+++ b/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-pandargt-eval.py
@@ -1,0 +1,10 @@
+"""PointPillars nuScenes-trained model evaluated on PandaSet PandarGT (forward-facing)."""
+
+_base_ = ['./pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py']
+
+ann_file = 'pkls/pandaset_pandargt_infos_test.pkl'
+
+test_dataloader = dict(dataset=dict(ann_file=ann_file))
+test_evaluator = dict(ann_file='data/datasets/pandaset/' + ann_file)
+val_dataloader = dict(dataset=dict(ann_file=ann_file))
+val_evaluator = dict(ann_file='data/datasets/pandaset/' + ann_file)

--- a/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-pandargt-eval.py
+++ b/configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-pandargt-eval.py
@@ -2,9 +2,9 @@
 
 _base_ = ['./pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py']
 
-ann_file = 'pkls/pandaset_pandargt_infos_test.pkl'
+ann_file = 'pandaset_pandargt_infos_test.pkl'
 
 test_dataloader = dict(dataset=dict(ann_file=ann_file))
-test_evaluator = dict(ann_file='data/datasets/pandaset/' + ann_file)
+test_evaluator = dict(ann_file='data/pandaset/' + ann_file)
 val_dataloader = dict(dataset=dict(ann_file=ann_file))
-val_evaluator = dict(ann_file='data/datasets/pandaset/' + ann_file)
+val_evaluator = dict(ann_file='data/pandaset/' + ann_file)

--- a/docs/en/advanced_guides/datasets/pandaset.md
+++ b/docs/en/advanced_guides/datasets/pandaset.md
@@ -6,10 +6,10 @@ This page provides tutorials about the usage of MMDetection3D for PandaSet datas
 
 [PandaSet](https://pandaset.org/) is an autonomous driving dataset released by Hesai Technology and Scale AI. It features a **dual-LiDAR** system:
 
-| Sensor | Type | Beams | Coverage | Range |
-|--------|------|-------|----------|-------|
-| Pandar64 | Mechanical spinning | 64 | 360° | ~200m |
-| PandarGT | Solid-state | Dense forward array | ~60° | ~200m |
+| Sensor   | Type                | Beams               | Coverage | Range |
+| -------- | ------------------- | ------------------- | -------- | ----- |
+| Pandar64 | Mechanical spinning | 64                  | 360°     | ~200m |
+| PandarGT | Solid-state         | Dense forward array | ~60°     | ~200m |
 
 The dataset contains 103 sequences × 80 frames = 8,240 frames, with 28 cuboid annotation categories.
 
@@ -77,18 +77,18 @@ PandaSet stores annotations in **world coordinates**. The converter handles:
 
 PandaSet has 28 cuboid categories. For cross-dataset evaluation with nuScenes models, they are mapped to 10 classes:
 
-| nuScenes Class | PandaSet Labels |
-|----------------|-----------------|
-| car | Car, Pickup Truck |
-| truck | Medium-sized Truck |
-| trailer | Towed Object |
-| bus | Bus / RV |
-| construction_vehicle | Construction Vehicle |
-| bicycle | Bicycle |
-| motorcycle | Motorcycle |
-| pedestrian | Pedestrian |
-| traffic_cone | Cones |
-| barrier | Road Barriers, Temporary Construction Barriers |
+| nuScenes Class       | PandaSet Labels                                |
+| -------------------- | ---------------------------------------------- |
+| car                  | Car, Pickup Truck                              |
+| truck                | Medium-sized Truck                             |
+| trailer              | Towed Object                                   |
+| bus                  | Bus / RV                                       |
+| construction_vehicle | Construction Vehicle                           |
+| bicycle              | Bicycle                                        |
+| motorcycle           | Motorcycle                                     |
+| pedestrian           | Pedestrian                                     |
+| traffic_cone         | Cones                                          |
+| barrier              | Road Barriers, Temporary Construction Barriers |
 
 Unmapped PandaSet labels (e.g., "Animals", "Emergency Vehicle", "Train") are ignored.
 
@@ -126,20 +126,20 @@ python tools/test.py \
 
 #### PointPillars FPN (nuScenes pretrained → PandaSet Pandar64)
 
-| Metric | Value | Notes |
-|--------|-------|-------|
-| mAP | 0.072 | Cross-dataset (vs 0.40 on nuScenes val) |
-| Car AP | 0.47 | Best transferring class |
-| Pedestrian AP | 0.21 | Second best |
-| NDS (partial) | 0.18 | No velocity/attribute errors |
-| Car AP (0-25m) | 0.72 | Strong near-range performance |
+| Metric         | Value | Notes                                   |
+| -------------- | ----- | --------------------------------------- |
+| mAP            | 0.072 | Cross-dataset (vs 0.40 on nuScenes val) |
+| Car AP         | 0.47  | Best transferring class                 |
+| Pedestrian AP  | 0.21  | Second best                             |
+| NDS (partial)  | 0.18  | No velocity/attribute errors            |
+| Car AP (0-25m) | 0.72  | Strong near-range performance           |
 
 #### PointPillars FPN (nuScenes pretrained → PandaSet PandarGT)
 
-| Metric | Value | Notes |
-|--------|-------|-------|
-| mAP | 0.006 | PandarGT is incompatible with 360° model |
-| Car AP | 0.05 | Severely degraded |
+| Metric | Value | Notes                                    |
+| ------ | ----- | ---------------------------------------- |
+| mAP    | 0.006 | PandarGT is incompatible with 360° model |
+| Car AP | 0.05  | Severely degraded                        |
 
 **Note:** PandarGT's 60° FOV is architecturally incompatible with models trained on 360° data. Only Pandar64 is suitable for cross-dataset evaluation with nuScenes/360° models.
 
@@ -148,7 +148,7 @@ python tools/test.py \
 The overall mAP (~7%) is significantly lower than nuScenes val (~40%) due to:
 
 1. **Sensor difference**: Hesai Pandar64 (64-beam) vs Velodyne VLP-32C (32-beam) — different point density and beam patterns
-2. **4th channel mismatch**: nuScenes model expects timestamp (≈0), PandaSet provides intensity (normalized to [0,1])
+2. **4th channel mismatch**: nuScenes model expects timestamp (≈0), PandaSet provides intensity (normalized to \[0,1\])
 3. **Annotation mismatch**: Some classes have different physical definitions (e.g., "trailer" is 3.85m in PandaSet vs 12.3m in nuScenes)
 4. **Size mismatch**: Objects like barriers have completely different dimensions between datasets
 
@@ -161,7 +161,7 @@ PandaSet uses an on-the-fly loading approach via `LoadPointsFromPandaSet`:
 1. Reads original `.pkl` files (Pandas DataFrames with columns: x, y, z, i, t, d)
 2. Filters by sensor ID (d=0 for Pandar64, d=1 for PandarGT)
 3. Transforms world coordinates to ego-centric frame using pose matrix
-4. Normalizes intensity from [0, 255] to [0, 1]
+4. Normalizes intensity from \[0, 255\] to \[0, 1\]
 
 This avoids pre-converting ~22 GB of point clouds to `.bin` format.
 

--- a/docs/en/advanced_guides/datasets/pandaset.md
+++ b/docs/en/advanced_guides/datasets/pandaset.md
@@ -1,0 +1,181 @@
+# PandaSet Dataset
+
+This page provides tutorials about the usage of MMDetection3D for PandaSet dataset.
+
+## Overview
+
+[PandaSet](https://pandaset.org/) is an autonomous driving dataset released by Hesai Technology and Scale AI. It features a **dual-LiDAR** system:
+
+| Sensor | Type | Beams | Coverage | Range |
+|--------|------|-------|----------|-------|
+| Pandar64 | Mechanical spinning | 64 | 360° | ~200m |
+| PandarGT | Solid-state | Dense forward array | ~60° | ~200m |
+
+The dataset contains 103 sequences × 80 frames = 8,240 frames, with 28 cuboid annotation categories.
+
+## Before Preparation
+
+Download PandaSet from [Kaggle](https://www.kaggle.com/datasets/usharengaraju/pandaset) or [ModelScope](https://www.modelscope.cn/) (~40 GB compressed, ~80 GB extracted).
+
+Organize the folder structure as follows:
+
+```
+mmdetection3d
+├── data
+│   ├── pandaset
+│   │   ├── sequences
+│   │   │   ├── 001
+│   │   │   │   ├── annotations
+│   │   │   │   │   └── cuboids
+│   │   │   │   │       ├── 00.pkl
+│   │   │   │   │       ├── 01.pkl
+│   │   │   │   │       └── ...
+│   │   │   │   ├── lidar
+│   │   │   │   │   ├── 00.pkl
+│   │   │   │   │   ├── 01.pkl
+│   │   │   │   │   ├── ...
+│   │   │   │   │   ├── poses.json
+│   │   │   │   │   └── timestamps.json
+│   │   │   │   └── meta
+│   │   │   │       └── gps.json
+│   │   │   ├── 002
+│   │   │   └── ...
+```
+
+## Dataset Preparation
+
+### Generate Info Files
+
+Run the PandaSet converter to generate annotation pickle files:
+
+```bash
+python tools/dataset_converters/pandaset_converter.py \
+    --pandaset-root data/pandaset/sequences \
+    --out-dir data/pandaset \
+    --sensors pandar64 pandargt \
+    --workers 8
+```
+
+This produces:
+
+```
+data/pandaset/
+├── pandaset_pandar64_infos_test.pkl   # 8240 frames, Pandar64 sensor
+├── pandaset_pandargt_infos_test.pkl   # 8240 frames, PandarGT sensor
+└── sequences/                          # Original data (symlink or actual)
+```
+
+### Coordinate Conventions
+
+PandaSet stores annotations in **world coordinates**. The converter handles:
+
+1. **World → Ego transform**: Using `lidar/poses.json` (4×4 matrix per frame)
+2. **Yaw alignment**: PandaSet yaw=0 along X-axis → +π/2 offset for nuScenes model compatibility
+3. **Z-center → Z-bottom**: PandaSet stores box center Z → subtract height/2 for MMDet3D convention
+
+### Label Mapping
+
+PandaSet has 28 cuboid categories. For cross-dataset evaluation with nuScenes models, they are mapped to 10 classes:
+
+| nuScenes Class | PandaSet Labels |
+|----------------|-----------------|
+| car | Car, Pickup Truck |
+| truck | Medium-sized Truck |
+| trailer | Towed Object |
+| bus | Bus / RV |
+| construction_vehicle | Construction Vehicle |
+| bicycle | Bicycle |
+| motorcycle | Motorcycle |
+| pedestrian | Pedestrian |
+| traffic_cone | Cones |
+| barrier | Road Barriers, Temporary Construction Barriers |
+
+Unmapped PandaSet labels (e.g., "Animals", "Emergency Vehicle", "Train") are ignored.
+
+## Evaluation
+
+### Cross-Dataset Evaluation with nuScenes Model
+
+PandaSet is primarily used for cross-dataset generalization testing. To evaluate a nuScenes-trained PointPillars model on PandaSet:
+
+```bash
+python tools/test.py \
+    configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py \
+    checkpoints/hv_pointpillars_fpn_sbn-all_4x8_2x_nus-3d_20210826_104936-fca299c1.pth
+```
+
+For PandarGT (forward-facing only):
+
+```bash
+python tools/test.py \
+    configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-pandargt-eval.py \
+    checkpoints/hv_pointpillars_fpn_sbn-all_4x8_2x_nus-3d_20210826_104936-fca299c1.pth
+```
+
+### Evaluation Metric
+
+`PandaSetMetric` implements the nuScenes-style evaluation protocol:
+
+- **Center-distance AP** at thresholds: 0.5m, 1.0m, 2.0m, 4.0m
+- **True Positive errors**: mATE (translation), mASE (scale), mAOE (orientation)
+- **NDS**: nuScenes Detection Score (partial — no velocity/attribute errors available)
+- **Distance-bin analysis**: AP breakdown at 0–25m and 25–50m ranges
+- **GT range filtering**: Only evaluates GT within the model's point_cloud_range
+
+### Results
+
+#### PointPillars FPN (nuScenes pretrained → PandaSet Pandar64)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| mAP | 0.072 | Cross-dataset (vs 0.40 on nuScenes val) |
+| Car AP | 0.47 | Best transferring class |
+| Pedestrian AP | 0.21 | Second best |
+| NDS (partial) | 0.18 | No velocity/attribute errors |
+| Car AP (0-25m) | 0.72 | Strong near-range performance |
+
+#### PointPillars FPN (nuScenes pretrained → PandaSet PandarGT)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| mAP | 0.006 | PandarGT is incompatible with 360° model |
+| Car AP | 0.05 | Severely degraded |
+
+**Note:** PandarGT's 60° FOV is architecturally incompatible with models trained on 360° data. Only Pandar64 is suitable for cross-dataset evaluation with nuScenes/360° models.
+
+### Why Cross-Dataset mAP is Low
+
+The overall mAP (~7%) is significantly lower than nuScenes val (~40%) due to:
+
+1. **Sensor difference**: Hesai Pandar64 (64-beam) vs Velodyne VLP-32C (32-beam) — different point density and beam patterns
+2. **4th channel mismatch**: nuScenes model expects timestamp (≈0), PandaSet provides intensity (normalized to [0,1])
+3. **Annotation mismatch**: Some classes have different physical definitions (e.g., "trailer" is 3.85m in PandaSet vs 12.3m in nuScenes)
+4. **Size mismatch**: Objects like barriers have completely different dimensions between datasets
+
+Classes that transfer well (car, pedestrian) have large, sensor-independent point cloud signatures. Classes that fail rely on sensor-specific point patterns or have annotation definition mismatches.
+
+## Data Loading
+
+PandaSet uses an on-the-fly loading approach via `LoadPointsFromPandaSet`:
+
+1. Reads original `.pkl` files (Pandas DataFrames with columns: x, y, z, i, t, d)
+2. Filters by sensor ID (d=0 for Pandar64, d=1 for PandarGT)
+3. Transforms world coordinates to ego-centric frame using pose matrix
+4. Normalizes intensity from [0, 255] to [0, 1]
+
+This avoids pre-converting ~22 GB of point clouds to `.bin` format.
+
+### Optional: Pre-conversion to .bin/.pcd
+
+For workflows requiring standard file formats:
+
+```bash
+python tools/convert_pandaset_to_bin_pcd.py
+```
+
+This generates ego-centric `.bin` (float32) and `.pcd` files per frame per sensor, with corresponding `_bin` info pickle files for use with standard `LoadPointsFromFile`.
+
+## Dual-LiDAR Notes
+
+- **Pandar64** (360° spinning): Suitable for cross-dataset evaluation with any 360° LiDAR model
+- **PandarGT** (60° forward): Only compatible with forward-facing or sector-based models; 360° models produce excessive false positives in empty BEV regions

--- a/mmdet3d/datasets/__init__.py
+++ b/mmdet3d/datasets/__init__.py
@@ -4,6 +4,7 @@ from .det3d_dataset import Det3DDataset
 from .kitti_dataset import KittiDataset
 from .lyft_dataset import LyftDataset
 from .nuscenes_dataset import NuScenesDataset
+from .pandaset_dataset import PandaSetDataset
 # yapf: enable
 from .s3dis_dataset import S3DISDataset, S3DISSegDataset
 from .scannet_dataset import (ScanNetDataset, ScanNetInstanceSegDataset,
@@ -38,4 +39,5 @@ __all__ = [
     'VoxelBasedPointSampler', 'get_loading_pipeline', 'RandomDropPointsColor',
     'RandomJitterPoints', 'ObjectNameFilter', 'AffineResize',
     'RandomShiftScale', 'LoadPointsFromDict', 'Resize3D', 'RandomResize3D',
+    'PandaSetDataset',
 ]

--- a/mmdet3d/datasets/pandaset_dataset.py
+++ b/mmdet3d/datasets/pandaset_dataset.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 """PandaSet dataset for MMDetection3D (evaluation only, no training)."""
 
 import numpy as np
@@ -11,14 +12,14 @@ from .det3d_dataset import Det3DDataset
 class PandaSetDataset(Det3DDataset):
     """PandaSet dataset mapped to nuScenes 10-class taxonomy.
 
-    Used for cross-dataset evaluation: model trained on nuScenes,
-    tested on PandaSet data converted via pandaset_converter.py.
+    Used for cross-dataset evaluation: model trained on nuScenes, tested on
+    PandaSet data converted via pandaset_converter.py.
     """
 
     METAINFO = {
-        'classes': ('car', 'truck', 'trailer', 'bus', 'construction_vehicle',
-                    'bicycle', 'motorcycle', 'pedestrian', 'traffic_cone',
-                    'barrier'),
+        'classes':
+        ('car', 'truck', 'trailer', 'bus', 'construction_vehicle', 'bicycle',
+         'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'),
     }
 
     def parse_ann_info(self, info):

--- a/mmdet3d/datasets/pandaset_dataset.py
+++ b/mmdet3d/datasets/pandaset_dataset.py
@@ -1,0 +1,38 @@
+"""PandaSet dataset for MMDetection3D (evaluation only, no training)."""
+
+import numpy as np
+
+from mmdet3d.registry import DATASETS
+from mmdet3d.structures import LiDARInstance3DBoxes
+from .det3d_dataset import Det3DDataset
+
+
+@DATASETS.register_module()
+class PandaSetDataset(Det3DDataset):
+    """PandaSet dataset mapped to nuScenes 10-class taxonomy.
+
+    Used for cross-dataset evaluation: model trained on nuScenes,
+    tested on PandaSet data converted via pandaset_converter.py.
+    """
+
+    METAINFO = {
+        'classes': ('car', 'truck', 'trailer', 'bus', 'construction_vehicle',
+                    'bicycle', 'motorcycle', 'pedestrian', 'traffic_cone',
+                    'barrier'),
+    }
+
+    def parse_ann_info(self, info):
+        """Process the `instances` in data info to `ann_info`."""
+        ann_info = super().parse_ann_info(info)
+        if ann_info is None:
+            ann_info = dict()
+            ann_info['gt_bboxes_3d'] = np.zeros((0, 7), dtype=np.float32)
+            ann_info['gt_labels_3d'] = np.zeros(0, dtype=np.int64)
+
+        ann_info = self._remove_dontcare(ann_info)
+        gt_bboxes_3d = LiDARInstance3DBoxes(
+            ann_info['gt_bboxes_3d'],
+            box_dim=ann_info['gt_bboxes_3d'].shape[-1],
+            origin=(0.5, 0.5, 0))
+        ann_info['gt_bboxes_3d'] = gt_bboxes_3d
+        return ann_info

--- a/mmdet3d/datasets/transforms/__init__.py
+++ b/mmdet3d/datasets/transforms/__init__.py
@@ -7,6 +7,7 @@ from .loading import (LidarDet3DInferencerLoader, LoadAnnotations3D,
                       LoadPointsFromMultiSweeps, MonoDet3DInferencerLoader,
                       MultiModalityDet3DInferencerLoader, NormalizePointsColor,
                       PointSegClassMapping)
+from .pandaset_loading import LoadPointsFromPandaSet, NormalizePointsIntensity
 from .test_time_aug import MultiScaleFlipAug3D
 # yapf: disable
 from .transforms_3d import (AffineResize, BackgroundPointsFilter,
@@ -32,5 +33,6 @@ __all__ = [
     'RandomShiftScale', 'LoadPointsFromDict', 'Resize3D', 'RandomResize3D',
     'MultiViewWrapper', 'PhotoMetricDistortion3D', 'MonoDet3DInferencerLoader',
     'LidarDet3DInferencerLoader', 'PolarMix', 'LaserMix',
-    'MultiModalityDet3DInferencerLoader'
+    'MultiModalityDet3DInferencerLoader', 'LoadPointsFromPandaSet',
+    'NormalizePointsIntensity'
 ]

--- a/mmdet3d/datasets/transforms/pandaset_loading.py
+++ b/mmdet3d/datasets/transforms/pandaset_loading.py
@@ -1,15 +1,15 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 """On-the-fly PandaSet point cloud loading transform for MMDetection3D.
 
-Reads the original PandaSet .pkl files directly, applies ego transform,
-filters by sensor ID, and returns points in the standard format expected
-by the PointPillars (or any LiDAR-based) model.
+Reads the original PandaSet .pkl files directly, applies ego transform, filters
+by sensor ID, and returns points in the standard format expected by the
+PointPillars (or any LiDAR-based) model.
 """
 
 import numpy as np
 import pandas as pd
 from mmcv.transforms import BaseTransform
 
-from mmdet3d.datasets.transforms.loading import LoadPointsFromFile
 from mmdet3d.registry import TRANSFORMS
 from mmdet3d.structures.points import get_points_type
 

--- a/mmdet3d/datasets/transforms/pandaset_loading.py
+++ b/mmdet3d/datasets/transforms/pandaset_loading.py
@@ -1,0 +1,98 @@
+"""On-the-fly PandaSet point cloud loading transform for MMDetection3D.
+
+Reads the original PandaSet .pkl files directly, applies ego transform,
+filters by sensor ID, and returns points in the standard format expected
+by the PointPillars (or any LiDAR-based) model.
+"""
+
+import numpy as np
+import pandas as pd
+from mmcv.transforms import BaseTransform
+
+from mmdet3d.datasets.transforms.loading import LoadPointsFromFile
+from mmdet3d.registry import TRANSFORMS
+from mmdet3d.structures.points import get_points_type
+
+
+@TRANSFORMS.register_module()
+class LoadPointsFromPandaSet(BaseTransform):
+    """Load points from PandaSet .pkl files with on-the-fly ego transform.
+
+    Required Keys:
+        - lidar_points (dict):
+            - lidar_path (str): path to the .pkl file
+            - pandaset_sensor_id (int): 0=Pandar64, 1=PandarGT
+            - pandaset_pose (list): 4x4 world-to-ego pose matrix
+
+    Added Keys:
+        - points (BasePoints): transformed point cloud
+
+    Args:
+        coord_type (str): Coordinate type ('LIDAR').
+        use_dim (int): Number of point dimensions to use. Default 4 (x,y,z,i).
+    """
+
+    def __init__(self, coord_type='LIDAR', use_dim=4):
+        self.coord_type = coord_type
+        self.use_dim = use_dim
+
+    def transform(self, results: dict) -> dict:
+        lidar_info = results['lidar_points']
+        pkl_path = lidar_info['lidar_path']
+        sensor_id = lidar_info['pandaset_sensor_id']
+        pose_mat = np.array(lidar_info['pandaset_pose'])
+
+        lidar_df = pd.read_pickle(pkl_path)
+        sensor_pts = lidar_df[lidar_df['d'] == sensor_id]
+
+        world_xyz = sensor_pts[['x', 'y', 'z']].values.astype(np.float64)
+        intensity = sensor_pts['i'].values.astype(np.float32) / 255.0
+
+        # Transform from world frame to ego/lidar frame
+        inv_pose = np.linalg.inv(pose_mat)
+        pts_h = np.hstack([world_xyz, np.ones((len(world_xyz), 1))])
+        ego_xyz = (inv_pose @ pts_h.T).T[:, :3].astype(np.float32)
+
+        points = np.column_stack([ego_xyz, intensity])
+
+        if self.use_dim < 4:
+            points = points[:, :self.use_dim]
+
+        points_class = get_points_type(self.coord_type)
+        points = points_class(points, points_dim=points.shape[-1])
+        results['points'] = points
+
+        return results
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}('
+                f'coord_type={self.coord_type}, use_dim={self.use_dim})')
+
+
+@TRANSFORMS.register_module()
+class NormalizePointsIntensity(BaseTransform):
+    """Normalize the intensity channel of loaded points.
+
+    The nuScenes PointPillars model uses timestamp (≈0) as its 4th channel,
+    not intensity. When feeding PandaSet .bin files (intensity in [0, 255]),
+    we normalize to [0, 1] to keep values near zero and compatible with the
+    model's learned batch normalization statistics.
+
+    Args:
+        intensity_dim (int): Index of the intensity channel. Default 3.
+        scale (float): Divisor for normalization. Default 255.0.
+    """
+
+    def __init__(self, intensity_dim=3, scale=255.0):
+        self.intensity_dim = intensity_dim
+        self.scale = scale
+
+    def transform(self, results: dict) -> dict:
+        points = results['points']
+        points.tensor[:, self.intensity_dim] /= self.scale
+        results['points'] = points
+        return results
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}('
+                f'intensity_dim={self.intensity_dim}, scale={self.scale})')

--- a/mmdet3d/evaluation/metrics/__init__.py
+++ b/mmdet3d/evaluation/metrics/__init__.py
@@ -4,11 +4,12 @@ from .instance_seg_metric import InstanceSegMetric  # noqa: F401,F403
 from .kitti_metric import KittiMetric  # noqa: F401,F403
 from .lyft_metric import LyftMetric  # noqa: F401,F403
 from .nuscenes_metric import NuScenesMetric  # noqa: F401,F403
+from .pandaset_metric import PandaSetMetric  # noqa: F401,F403
 from .panoptic_seg_metric import PanopticSegMetric  # noqa: F401,F403
 from .seg_metric import SegMetric  # noqa: F401,F403
 from .waymo_metric import WaymoMetric  # noqa: F401,F403
 
 __all__ = [
     'KittiMetric', 'NuScenesMetric', 'IndoorMetric', 'LyftMetric', 'SegMetric',
-    'InstanceSegMetric', 'WaymoMetric', 'PanopticSegMetric'
+    'InstanceSegMetric', 'WaymoMetric', 'PanopticSegMetric', 'PandaSetMetric'
 ]

--- a/mmdet3d/evaluation/metrics/pandaset_metric.py
+++ b/mmdet3d/evaluation/metrics/pandaset_metric.py
@@ -11,15 +11,14 @@ Reference: Caesar et al., "nuScenes: A multimodal dataset for autonomous
 driving", CVPR 2020.
 """
 
-import numpy as np
-from typing import Dict, List, Optional, Sequence
 from collections import OrderedDict
+from typing import Dict, List, Optional, Sequence
 
+import numpy as np
 from mmengine.evaluator import BaseMetric
 from mmengine.logging import print_log
 
 from mmdet3d.registry import METRICS
-from mmdet3d.structures import LiDARInstance3DBoxes
 
 DIST_THRESHOLDS = [0.5, 1.0, 2.0, 4.0]
 TP_DIST_THRESHOLD = 2.0
@@ -30,7 +29,10 @@ def center_distance_2d(box_a, box_b):
     return np.sqrt((box_a[0] - box_b[0])**2 + (box_a[1] - box_b[1])**2)
 
 
-def accumulate_ap(all_scores, all_matches, total_gt, min_recall=0.1,
+def accumulate_ap(all_scores,
+                  all_matches,
+                  total_gt,
+                  min_recall=0.1,
                   min_precision=0.1):
     """Compute AP using nuScenes protocol.
 
@@ -134,9 +136,9 @@ def compute_scale_error(dt_box, gt_box):
     if vol_dt <= 0 or vol_gt <= 0:
         return 1.0
 
-    inter = (min(dt_dims[0], gt_dims[0]) *
-             min(dt_dims[1], gt_dims[1]) *
-             min(dt_dims[2], gt_dims[2]))
+    inter = (
+        min(dt_dims[0], gt_dims[0]) * min(dt_dims[1], gt_dims[1]) *
+        min(dt_dims[2], gt_dims[2]))
     iou = inter / (vol_dt + vol_gt - inter)
     return 1.0 - iou
 
@@ -216,8 +218,10 @@ class PandaSetMetric(BaseMetric):
     def compute_metrics(self, results: List[dict]) -> Dict[str, float]:
         """Compute nuScenes-style metrics: mAP, mATE, mASE, mAOE, NDS."""
         print_log('\n' + '=' * 70, logger='current')
-        print_log('PandaSet Evaluation (nuScenes-style center-distance protocol)',
-                  logger='current')
+        print_log(
+            'PandaSet Evaluation (nuScenes-style '
+            'center-distance protocol)',
+            logger='current')
         print_log('=' * 70, logger='current')
 
         all_dt_boxes = [r['bboxes_3d'] for r in results]
@@ -234,10 +238,9 @@ class PandaSetMetric(BaseMetric):
             # --- AP at each distance threshold ---
             aps_for_class = []
             for dist_th in DIST_THRESHOLDS:
-                ap = self._eval_class_ap(
-                    all_dt_boxes, all_dt_scores, all_dt_labels,
-                    all_gt_boxes, all_gt_labels,
-                    cls_idx, dist_th)
+                ap = self._eval_class_ap(all_dt_boxes, all_dt_scores,
+                                         all_dt_labels, all_gt_boxes,
+                                         all_gt_labels, cls_idx, dist_th)
                 aps_for_class.append(ap)
                 ap_dict[f'{cls_name}/AP_dist_{dist_th}'] = ap
 
@@ -246,10 +249,10 @@ class PandaSetMetric(BaseMetric):
             class_aps.append(mean_ap_cls)
 
             # --- TP errors at 2m threshold ---
-            tp_errors = self._eval_class_tp_errors(
-                all_dt_boxes, all_dt_scores, all_dt_labels,
-                all_gt_boxes, all_gt_labels,
-                cls_idx, TP_DIST_THRESHOLD)
+            tp_errors = self._eval_class_tp_errors(all_dt_boxes, all_dt_scores,
+                                                   all_dt_labels, all_gt_boxes,
+                                                   all_gt_labels, cls_idx,
+                                                   TP_DIST_THRESHOLD)
             class_tp_errors.append(tp_errors)
 
             if tp_errors is not None:
@@ -264,9 +267,15 @@ class PandaSetMetric(BaseMetric):
         # --- Aggregate metrics ---
         mAP = float(np.mean(class_aps))
 
-        ate_vals = [e['ate'] if e is not None else 1.0 for e in class_tp_errors]
-        ase_vals = [e['ase'] if e is not None else 1.0 for e in class_tp_errors]
-        aoe_vals = [e['aoe'] if e is not None else 1.0 for e in class_tp_errors]
+        ate_vals = [
+            e['ate'] if e is not None else 1.0 for e in class_tp_errors
+        ]
+        ase_vals = [
+            e['ase'] if e is not None else 1.0 for e in class_tp_errors
+        ]
+        aoe_vals = [
+            e['aoe'] if e is not None else 1.0 for e in class_tp_errors
+        ]
 
         mATE = float(np.mean(ate_vals))
         mASE = float(np.mean(ase_vals))
@@ -299,8 +308,8 @@ class PandaSetMetric(BaseMetric):
 
         # --- Distance-bin analysis ---
         dist_bin_results = self._compute_distance_bin_analysis(
-            all_dt_boxes, all_dt_scores, all_dt_labels,
-            all_gt_boxes, all_gt_labels)
+            all_dt_boxes, all_dt_scores, all_dt_labels, all_gt_boxes,
+            all_gt_labels)
         ap_dict.update(dist_bin_results)
 
         return ap_dict
@@ -313,8 +322,8 @@ class PandaSetMetric(BaseMetric):
         total_gt = 0
 
         for dt_boxes, dt_scores, dt_labels, gt_boxes, gt_labels in zip(
-                all_dt_boxes, all_dt_scores, all_dt_labels,
-                all_gt_boxes, all_gt_labels):
+                all_dt_boxes, all_dt_scores, all_dt_labels, all_gt_boxes,
+                all_gt_labels):
 
             dt_mask = dt_labels == class_id
             gt_mask = gt_labels == class_id
@@ -372,8 +381,8 @@ class PandaSetMetric(BaseMetric):
         total_gt = 0
 
         for dt_boxes, dt_scores, dt_labels, gt_boxes, gt_labels in zip(
-                all_dt_boxes, all_dt_scores, all_dt_labels,
-                all_gt_boxes, all_gt_labels):
+                all_dt_boxes, all_dt_scores, all_dt_labels, all_gt_boxes,
+                all_gt_labels):
 
             dt_mask = dt_labels == class_id
             gt_mask = gt_labels == class_id
@@ -431,8 +440,8 @@ class PandaSetMetric(BaseMetric):
         return compute_tp_errors(tp_list)
 
     def _compute_distance_bin_analysis(self, all_dt_boxes, all_dt_scores,
-                                        all_dt_labels, all_gt_boxes,
-                                        all_gt_labels):
+                                       all_dt_labels, all_gt_boxes,
+                                       all_gt_labels):
         """Compute per-distance-bin AP for each class.
 
         Bins: 0-25m (near-range), 25-50m (far-range).
@@ -443,8 +452,9 @@ class PandaSetMetric(BaseMetric):
         ap_dict = OrderedDict()
 
         print_log('\n' + '=' * 70, logger='current')
-        print_log('Distance-Bin Analysis (AP by BEV range from ego)',
-                  logger='current')
+        print_log(
+            'Distance-Bin Analysis (AP by BEV range from ego)',
+            logger='current')
         print_log('=' * 70, logger='current')
 
         header = f'\n{"Class":<25} '
@@ -458,7 +468,8 @@ class PandaSetMetric(BaseMetric):
         for cls_idx, cls_name in enumerate(self.classes):
             # Count total GT in range for this class
             total_gt_all = sum(
-                int((gt_labels == cls_idx).sum()) for gt_labels in all_gt_labels)
+                int((gt_labels == cls_idx).sum())
+                for gt_labels in all_gt_labels)
             if total_gt_all < 10:
                 continue
 
@@ -469,8 +480,8 @@ class PandaSetMetric(BaseMetric):
                 for dist_th in DIST_THRESHOLDS:
                     ap, n_gt = self._eval_class_ap_range(
                         all_dt_boxes, all_dt_scores, all_dt_labels,
-                        all_gt_boxes, all_gt_labels,
-                        cls_idx, dist_th, rmin, rmax)
+                        all_gt_boxes, all_gt_labels, cls_idx, dist_th, rmin,
+                        rmax)
                     bin_aps.append(ap)
                     bin_gt_count = n_gt
 
@@ -486,10 +497,10 @@ class PandaSetMetric(BaseMetric):
             # Full range AP (already computed, recompute for consistency)
             full_aps = []
             for dist_th in DIST_THRESHOLDS:
-                ap, _ = self._eval_class_ap_range(
-                    all_dt_boxes, all_dt_scores, all_dt_labels,
-                    all_gt_boxes, all_gt_labels,
-                    cls_idx, dist_th, 0, 50)
+                ap, _ = self._eval_class_ap_range(all_dt_boxes, all_dt_scores,
+                                                  all_dt_labels, all_gt_boxes,
+                                                  all_gt_labels, cls_idx,
+                                                  dist_th, 0, 50)
                 full_aps.append(ap)
             full_ap = float(np.mean(full_aps))
             row += f'{full_ap:<10.4f}'
@@ -498,8 +509,9 @@ class PandaSetMetric(BaseMetric):
             any_printed = True
 
         if not any_printed:
-            print_log('  (No classes with >= 10 GT objects in range)',
-                      logger='current')
+            print_log(
+                '  (No classes with >= 10 GT objects in range)',
+                logger='current')
 
         print_log('-' * 80 + '\n', logger='current')
         return ap_dict
@@ -507,8 +519,8 @@ class PandaSetMetric(BaseMetric):
     def _eval_class_ap_range(self, all_dt_boxes, all_dt_scores, all_dt_labels,
                              all_gt_boxes, all_gt_labels, class_id,
                              dist_threshold, range_min, range_max):
-        """Compute AP for one class at one distance threshold, filtered by
-        BEV distance range.
+        """Compute AP for one class at one distance threshold, filtered by BEV
+        distance range.
 
         Both GT and predictions are filtered to [range_min, range_max) BEV
         distance from ego before matching.
@@ -521,8 +533,8 @@ class PandaSetMetric(BaseMetric):
         total_gt = 0
 
         for dt_boxes, dt_scores, dt_labels, gt_boxes, gt_labels in zip(
-                all_dt_boxes, all_dt_scores, all_dt_labels,
-                all_gt_boxes, all_gt_labels):
+                all_dt_boxes, all_dt_scores, all_dt_labels, all_gt_boxes,
+                all_gt_labels):
 
             dt_mask = dt_labels == class_id
             gt_mask = gt_labels == class_id
@@ -533,16 +545,18 @@ class PandaSetMetric(BaseMetric):
 
             # Filter GT by BEV distance
             if len(gt_cls_boxes) > 0:
-                gt_dists = np.sqrt(
-                    gt_cls_boxes[:, 0]**2 + gt_cls_boxes[:, 1]**2)
-                gt_range_mask = (gt_dists >= range_min) & (gt_dists < range_max)
+                gt_dists = np.sqrt(gt_cls_boxes[:, 0]**2 +
+                                   gt_cls_boxes[:, 1]**2)
+                gt_range_mask = ((gt_dists >= range_min)
+                                 & (gt_dists < range_max))
                 gt_cls_boxes = gt_cls_boxes[gt_range_mask]
 
             # Filter predictions by BEV distance
             if len(dt_cls_boxes) > 0:
-                dt_dists = np.sqrt(
-                    dt_cls_boxes[:, 0]**2 + dt_cls_boxes[:, 1]**2)
-                dt_range_mask = (dt_dists >= range_min) & (dt_dists < range_max)
+                dt_dists = np.sqrt(dt_cls_boxes[:, 0]**2 +
+                                   dt_cls_boxes[:, 1]**2)
+                dt_range_mask = ((dt_dists >= range_min)
+                                 & (dt_dists < range_max))
                 dt_cls_boxes = dt_cls_boxes[dt_range_mask]
                 dt_cls_scores = dt_cls_scores[dt_range_mask]
 
@@ -584,12 +598,13 @@ class PandaSetMetric(BaseMetric):
         ap = accumulate_ap(all_scores, all_matches, total_gt)
         return ap, total_gt
 
-    def _print_results(self, class_aps, class_tp_errors, mAP, mATE, mASE,
-                       mAOE, nds, nds_partial):
+    def _print_results(self, class_aps, class_tp_errors, mAP, mATE, mASE, mAOE,
+                       nds, nds_partial):
         """Print results in nuScenes-style format."""
         sep = '-' * 70
         result_str = f'\n{sep}\n'
-        result_str += f'{"Object Class":<25} {"AP":<8} {"ATE":<8} {"ASE":<8} {"AOE":<8}\n'
+        result_str += (f'{"Object Class":<25} {"AP":<8} {"ATE":<8} '
+                       f'{"ASE":<8} {"AOE":<8}\n')
         result_str += f'{sep}\n'
 
         for cls_idx, cls_name in enumerate(self.classes):
@@ -603,15 +618,16 @@ class PandaSetMetric(BaseMetric):
                 ate_str = 'N/A'
                 ase_str = 'N/A'
                 aoe_str = 'N/A'
-            result_str += f'{cls_name:<25} {ap_str:<8} {ate_str:<8} {ase_str:<8} {aoe_str:<8}\n'
+            result_str += (f'{cls_name:<25} {ap_str:<8} {ate_str:<8} '
+                           f'{ase_str:<8} {aoe_str:<8}\n')
 
         result_str += f'{sep}\n'
         result_str += f'mAP:  {mAP:.4f}\n'
         result_str += f'mATE: {mATE:.4f}\n'
         result_str += f'mASE: {mASE:.4f}\n'
         result_str += f'mAOE: {mAOE:.4f}\n'
-        result_str += f'mAVE: N/A (no velocity in PandaSet)\n'
-        result_str += f'mAAE: N/A (no attributes in PandaSet)\n'
+        result_str += 'mAVE: N/A (no velocity in PandaSet)\n'
+        result_str += 'mAAE: N/A (no attributes in PandaSet)\n'
         result_str += f'NDS:  {nds:.4f} (with mAVE=1, mAAE=1)\n'
         result_str += f'NDS (partial, 3 TP metrics only): {nds_partial:.4f}\n'
         result_str += f'{sep}\n'

--- a/mmdet3d/evaluation/metrics/pandaset_metric.py
+++ b/mmdet3d/evaluation/metrics/pandaset_metric.py
@@ -1,0 +1,619 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""PandaSet evaluation metric using nuScenes-style center-distance protocol.
+
+Implements the official nuScenes detection evaluation:
+  - Matching by 2D BEV center distance (not IoU)
+  - AP averaged over distance thresholds {0.5, 1, 2, 4} meters
+  - TP error metrics: ATE, ASE, AOE
+  - NDS (nuScenes Detection Score)
+
+Reference: Caesar et al., "nuScenes: A multimodal dataset for autonomous
+driving", CVPR 2020.
+"""
+
+import numpy as np
+from typing import Dict, List, Optional, Sequence
+from collections import OrderedDict
+
+from mmengine.evaluator import BaseMetric
+from mmengine.logging import print_log
+
+from mmdet3d.registry import METRICS
+from mmdet3d.structures import LiDARInstance3DBoxes
+
+DIST_THRESHOLDS = [0.5, 1.0, 2.0, 4.0]
+TP_DIST_THRESHOLD = 2.0
+
+
+def center_distance_2d(box_a, box_b):
+    """2D Euclidean distance between box centers on the BEV plane (x, y)."""
+    return np.sqrt((box_a[0] - box_b[0])**2 + (box_a[1] - box_b[1])**2)
+
+
+def accumulate_ap(all_scores, all_matches, total_gt, min_recall=0.1,
+                  min_precision=0.1):
+    """Compute AP using nuScenes protocol.
+
+    Integrates the P-R curve only where both recall > min_recall and
+    precision > min_precision. Returns 0 if 10% recall is never reached.
+
+    Args:
+        all_scores (np.ndarray): Confidence scores for all detections.
+        all_matches (np.ndarray): Boolean, True if detection is a TP.
+        total_gt (int): Total number of ground truth objects.
+        min_recall (float): Minimum recall threshold.
+        min_precision (float): Minimum precision threshold.
+
+    Returns:
+        float: Average Precision (0 to 1 scale).
+    """
+    if total_gt == 0 or len(all_scores) == 0:
+        return 0.0
+
+    sort_idx = np.argsort(-all_scores)
+    all_matches = all_matches[sort_idx]
+
+    tp_cumsum = np.cumsum(all_matches)
+    fp_cumsum = np.cumsum(~all_matches)
+    recall = tp_cumsum / total_gt
+    precision = tp_cumsum / (tp_cumsum + fp_cumsum)
+
+    valid = (recall >= min_recall) & (precision >= min_precision)
+    if not np.any(valid):
+        return 0.0
+
+    recall_valid = recall[valid]
+    precision_valid = precision[valid]
+
+    n_sample = 101
+    recall_interp = np.linspace(min_recall, 1.0, n_sample)
+    precision_interp = np.zeros(n_sample)
+    for i, r in enumerate(recall_interp):
+        precs = precision_valid[recall_valid >= r]
+        if len(precs) > 0:
+            precision_interp[i] = np.max(precs)
+
+    ap = np.mean(precision_interp)
+    return ap
+
+
+def compute_tp_errors(tp_list):
+    """Compute TP error metrics from matched TP pairs.
+
+    Uses the nuScenes protocol: cumulative mean at each recall level,
+    then average over recall levels above 10%.
+
+    Args:
+        tp_list: List of dicts with keys 'score', 'ate', 'ase', 'aoe'.
+
+    Returns:
+        dict: {'ate': float, 'ase': float, 'aoe': float} or None if < 10%
+              recall is achieved.
+    """
+    if len(tp_list) == 0:
+        return None
+
+    tp_arr = sorted(tp_list, key=lambda x: -x['score'])
+    ates = np.array([t['ate'] for t in tp_arr])
+    ases = np.array([t['ase'] for t in tp_arr])
+    aoes = np.array([t['aoe'] for t in tp_arr])
+
+    cum_ate = np.cumsum(ates) / np.arange(1, len(ates) + 1)
+    cum_ase = np.cumsum(ases) / np.arange(1, len(ases) + 1)
+    cum_aoe = np.cumsum(aoes) / np.arange(1, len(aoes) + 1)
+
+    return {
+        'ate': float(np.mean(cum_ate)),
+        'ase': float(np.mean(cum_ase)),
+        'aoe': float(np.mean(cum_aoe)),
+    }
+
+
+def yaw_diff(yaw_a, yaw_b):
+    """Smallest absolute angle difference between two yaw angles."""
+    diff = abs(yaw_a - yaw_b)
+    diff = diff % (2 * np.pi)
+    if diff > np.pi:
+        diff = 2 * np.pi - diff
+    return diff
+
+
+def compute_scale_error(dt_box, gt_box):
+    """Compute ASE = 1 - IoU3D after center and orientation alignment.
+
+    Aligns the boxes (same center, same yaw) and computes volume overlap.
+    This reduces to 1 - (min(dx)/max(dx) * min(dy)/max(dy) * min(dz)/max(dz))
+    for axis-aligned boxes of same center.
+    """
+    dt_dims = dt_box[3:6]  # dx, dy, dz
+    gt_dims = gt_box[3:6]
+
+    vol_dt = dt_dims[0] * dt_dims[1] * dt_dims[2]
+    vol_gt = gt_dims[0] * gt_dims[1] * gt_dims[2]
+
+    if vol_dt <= 0 or vol_gt <= 0:
+        return 1.0
+
+    inter = (min(dt_dims[0], gt_dims[0]) *
+             min(dt_dims[1], gt_dims[1]) *
+             min(dt_dims[2], gt_dims[2]))
+    iou = inter / (vol_dt + vol_gt - inter)
+    return 1.0 - iou
+
+
+@METRICS.register_module()
+class PandaSetMetric(BaseMetric):
+    """PandaSet evaluation using nuScenes-style center-distance protocol.
+
+    Computes:
+      - mAP: mean AP over center-distance thresholds {0.5, 1, 2, 4}m
+      - mATE: mean Average Translation Error (2D Euclidean, meters)
+      - mASE: mean Average Scale Error (1 - IoU after alignment)
+      - mAOE: mean Average Orientation Error (yaw angle diff, radians)
+      - NDS: nuScenes Detection Score
+
+    Args:
+        ann_file (str): Path to the annotation info pkl file.
+        metric (str): Unused, kept for interface compatibility.
+        pcd_limit_range (list, optional): Point cloud range for GT filtering.
+        collect_device (str): Device for collecting results.
+        prefix (str, optional): Prefix for metric keys.
+    """
+
+    def __init__(self,
+                 ann_file: str,
+                 metric: str = 'bbox',
+                 pcd_limit_range: Optional[list] = None,
+                 collect_device: str = 'cpu',
+                 prefix: Optional[str] = None):
+        super().__init__(collect_device=collect_device, prefix=prefix)
+        self.ann_file = ann_file
+        if pcd_limit_range is not None:
+            self.pcd_limit_range = pcd_limit_range
+        else:
+            self.pcd_limit_range = [-50, -50, -5, 50, 50, 3]
+
+        import pickle
+        with open(ann_file, 'rb') as f:
+            self.data_infos = pickle.load(f)
+        self.classes = list(self.data_infos['metainfo']['CLASSES'])
+
+    def process(self, data_batch: dict, data_samples: Sequence[dict]) -> None:
+        """Process predictions and GT for one batch."""
+        for data_sample in data_samples:
+            result = dict()
+            pred = data_sample['pred_instances_3d']
+            result['bboxes_3d'] = pred['bboxes_3d'].tensor.cpu().numpy()
+            result['scores_3d'] = pred['scores_3d'].cpu().numpy()
+            result['labels_3d'] = pred['labels_3d'].cpu().numpy()
+
+            eval_ann = data_sample['eval_ann_info']
+            gt_bboxes = eval_ann['gt_bboxes_3d']
+            if hasattr(gt_bboxes, 'tensor'):
+                gt_bboxes = gt_bboxes.tensor.cpu().numpy()
+            elif not isinstance(gt_bboxes, np.ndarray):
+                gt_bboxes = np.array(gt_bboxes)
+
+            gt_labels = eval_ann['gt_labels_3d']
+            if hasattr(gt_labels, 'numpy'):
+                gt_labels = gt_labels.numpy()
+
+            # Filter GT to detection range
+            if len(gt_bboxes) > 0 and self.pcd_limit_range is not None:
+                pcr = self.pcd_limit_range
+                centers = gt_bboxes[:, :3]
+                mask = ((centers[:, 0] >= pcr[0]) & (centers[:, 0] <= pcr[3]) &
+                        (centers[:, 1] >= pcr[1]) & (centers[:, 1] <= pcr[4]) &
+                        (centers[:, 2] >= pcr[2]) & (centers[:, 2] <= pcr[5]))
+                gt_bboxes = gt_bboxes[mask]
+                gt_labels = gt_labels[mask]
+
+            result['gt_bboxes_3d'] = gt_bboxes
+            result['gt_labels_3d'] = gt_labels
+
+            self.results.append(result)
+
+    def compute_metrics(self, results: List[dict]) -> Dict[str, float]:
+        """Compute nuScenes-style metrics: mAP, mATE, mASE, mAOE, NDS."""
+        print_log('\n' + '=' * 70, logger='current')
+        print_log('PandaSet Evaluation (nuScenes-style center-distance protocol)',
+                  logger='current')
+        print_log('=' * 70, logger='current')
+
+        all_dt_boxes = [r['bboxes_3d'] for r in results]
+        all_dt_scores = [r['scores_3d'] for r in results]
+        all_dt_labels = [r['labels_3d'] for r in results]
+        all_gt_boxes = [r['gt_bboxes_3d'] for r in results]
+        all_gt_labels = [r['gt_labels_3d'] for r in results]
+
+        ap_dict = OrderedDict()
+        class_aps = []
+        class_tp_errors = []
+
+        for cls_idx, cls_name in enumerate(self.classes):
+            # --- AP at each distance threshold ---
+            aps_for_class = []
+            for dist_th in DIST_THRESHOLDS:
+                ap = self._eval_class_ap(
+                    all_dt_boxes, all_dt_scores, all_dt_labels,
+                    all_gt_boxes, all_gt_labels,
+                    cls_idx, dist_th)
+                aps_for_class.append(ap)
+                ap_dict[f'{cls_name}/AP_dist_{dist_th}'] = ap
+
+            mean_ap_cls = float(np.mean(aps_for_class))
+            ap_dict[f'{cls_name}/AP'] = mean_ap_cls
+            class_aps.append(mean_ap_cls)
+
+            # --- TP errors at 2m threshold ---
+            tp_errors = self._eval_class_tp_errors(
+                all_dt_boxes, all_dt_scores, all_dt_labels,
+                all_gt_boxes, all_gt_labels,
+                cls_idx, TP_DIST_THRESHOLD)
+            class_tp_errors.append(tp_errors)
+
+            if tp_errors is not None:
+                ap_dict[f'{cls_name}/ATE'] = tp_errors['ate']
+                ap_dict[f'{cls_name}/ASE'] = tp_errors['ase']
+                ap_dict[f'{cls_name}/AOE'] = tp_errors['aoe']
+            else:
+                ap_dict[f'{cls_name}/ATE'] = 1.0
+                ap_dict[f'{cls_name}/ASE'] = 1.0
+                ap_dict[f'{cls_name}/AOE'] = 1.0
+
+        # --- Aggregate metrics ---
+        mAP = float(np.mean(class_aps))
+
+        ate_vals = [e['ate'] if e is not None else 1.0 for e in class_tp_errors]
+        ase_vals = [e['ase'] if e is not None else 1.0 for e in class_tp_errors]
+        aoe_vals = [e['aoe'] if e is not None else 1.0 for e in class_tp_errors]
+
+        mATE = float(np.mean(ate_vals))
+        mASE = float(np.mean(ase_vals))
+        mAOE = float(np.mean(aoe_vals))
+
+        # NDS with 5 TP metrics (AVE=1, AAE=1 since unavailable)
+        tp_scores = [
+            max(1.0 - mATE, 0.0),
+            max(1.0 - mASE, 0.0),
+            max(1.0 - mAOE, 0.0),
+            0.0,  # 1 - min(1, mAVE=1) = 0
+            0.0,  # 1 - min(1, mAAE=1) = 0
+        ]
+        nds = (5.0 * mAP + sum(tp_scores)) / 10.0
+
+        # NDS partial (only 3 available TP metrics)
+        tp_scores_partial = tp_scores[:3]
+        nds_partial = (5.0 * mAP + sum(tp_scores_partial)) / 8.0
+
+        ap_dict['mAP'] = mAP
+        ap_dict['mATE'] = mATE
+        ap_dict['mASE'] = mASE
+        ap_dict['mAOE'] = mAOE
+        ap_dict['NDS'] = nds
+        ap_dict['NDS_partial'] = nds_partial
+
+        # --- Print formatted results ---
+        self._print_results(class_aps, class_tp_errors, mAP, mATE, mASE, mAOE,
+                            nds, nds_partial)
+
+        # --- Distance-bin analysis ---
+        dist_bin_results = self._compute_distance_bin_analysis(
+            all_dt_boxes, all_dt_scores, all_dt_labels,
+            all_gt_boxes, all_gt_labels)
+        ap_dict.update(dist_bin_results)
+
+        return ap_dict
+
+    def _eval_class_ap(self, all_dt_boxes, all_dt_scores, all_dt_labels,
+                       all_gt_boxes, all_gt_labels, class_id, dist_threshold):
+        """Compute AP for one class at one center-distance threshold."""
+        all_scores = []
+        all_matches = []
+        total_gt = 0
+
+        for dt_boxes, dt_scores, dt_labels, gt_boxes, gt_labels in zip(
+                all_dt_boxes, all_dt_scores, all_dt_labels,
+                all_gt_boxes, all_gt_labels):
+
+            dt_mask = dt_labels == class_id
+            gt_mask = gt_labels == class_id
+
+            dt_cls_boxes = dt_boxes[dt_mask]
+            dt_cls_scores = dt_scores[dt_mask]
+            gt_cls_boxes = gt_boxes[gt_mask]
+
+            num_gt = len(gt_cls_boxes)
+            total_gt += num_gt
+
+            if len(dt_cls_boxes) == 0:
+                continue
+
+            if num_gt == 0:
+                all_scores.extend(dt_cls_scores.tolist())
+                all_matches.extend([False] * len(dt_cls_scores))
+                continue
+
+            # Compute BEV center distances (N_dt x N_gt)
+            dt_centers = dt_cls_boxes[:, :2]
+            gt_centers = gt_cls_boxes[:, :2]
+            dist_matrix = np.sqrt(
+                ((dt_centers[:, None, :] - gt_centers[None, :, :])**2).sum(-1))
+
+            # Greedy matching: sort detections by score, assign closest GT
+            sort_idx = np.argsort(-dt_cls_scores)
+            gt_matched = np.zeros(num_gt, dtype=bool)
+
+            for idx in sort_idx:
+                dists = dist_matrix[idx]
+                # Mask already-matched GT
+                dists_masked = dists.copy()
+                dists_masked[gt_matched] = np.inf
+                best_gt = np.argmin(dists_masked)
+
+                if dists_masked[best_gt] <= dist_threshold:
+                    gt_matched[best_gt] = True
+                    all_scores.append(dt_cls_scores[idx])
+                    all_matches.append(True)
+                else:
+                    all_scores.append(dt_cls_scores[idx])
+                    all_matches.append(False)
+
+        all_scores = np.array(all_scores)
+        all_matches = np.array(all_matches, dtype=bool)
+
+        return accumulate_ap(all_scores, all_matches, total_gt)
+
+    def _eval_class_tp_errors(self, all_dt_boxes, all_dt_scores, all_dt_labels,
+                              all_gt_boxes, all_gt_labels, class_id,
+                              dist_threshold):
+        """Compute TP error metrics (ATE, ASE, AOE) for one class at 2m."""
+        tp_list = []
+        total_gt = 0
+
+        for dt_boxes, dt_scores, dt_labels, gt_boxes, gt_labels in zip(
+                all_dt_boxes, all_dt_scores, all_dt_labels,
+                all_gt_boxes, all_gt_labels):
+
+            dt_mask = dt_labels == class_id
+            gt_mask = gt_labels == class_id
+
+            dt_cls_boxes = dt_boxes[dt_mask]
+            dt_cls_scores = dt_scores[dt_mask]
+            gt_cls_boxes = gt_boxes[gt_mask]
+
+            num_gt = len(gt_cls_boxes)
+            total_gt += num_gt
+
+            if len(dt_cls_boxes) == 0 or num_gt == 0:
+                continue
+
+            dt_centers = dt_cls_boxes[:, :2]
+            gt_centers = gt_cls_boxes[:, :2]
+            dist_matrix = np.sqrt(
+                ((dt_centers[:, None, :] - gt_centers[None, :, :])**2).sum(-1))
+
+            sort_idx = np.argsort(-dt_cls_scores)
+            gt_matched = np.zeros(num_gt, dtype=bool)
+
+            for idx in sort_idx:
+                dists = dist_matrix[idx]
+                dists_masked = dists.copy()
+                dists_masked[gt_matched] = np.inf
+                best_gt = np.argmin(dists_masked)
+
+                if dists_masked[best_gt] <= dist_threshold:
+                    gt_matched[best_gt] = True
+                    dt_box = dt_cls_boxes[idx]
+                    gt_box = gt_cls_boxes[best_gt]
+
+                    ate = float(dists[best_gt])
+                    ase = compute_scale_error(dt_box[:7], gt_box[:7])
+
+                    dt_yaw = dt_box[6] if dt_box.shape[0] > 6 else 0.0
+                    gt_yaw = gt_box[6] if gt_box.shape[0] > 6 else 0.0
+                    aoe = yaw_diff(dt_yaw, gt_yaw)
+
+                    tp_list.append({
+                        'score': float(dt_cls_scores[idx]),
+                        'ate': ate,
+                        'ase': ase,
+                        'aoe': aoe,
+                    })
+
+        if total_gt == 0:
+            return None
+
+        # Check if at least 10% recall is achieved
+        if len(tp_list) / max(total_gt, 1) < 0.1:
+            return None
+
+        return compute_tp_errors(tp_list)
+
+    def _compute_distance_bin_analysis(self, all_dt_boxes, all_dt_scores,
+                                        all_dt_labels, all_gt_boxes,
+                                        all_gt_labels):
+        """Compute per-distance-bin AP for each class.
+
+        Bins: 0-25m (near-range), 25-50m (far-range).
+        Uses center-distance matching averaged over {0.5, 1, 2, 4}m thresholds.
+        """
+        dist_bins = [(0, 25), (25, 50)]
+        bin_labels = ['0-25m', '25-50m']
+        ap_dict = OrderedDict()
+
+        print_log('\n' + '=' * 70, logger='current')
+        print_log('Distance-Bin Analysis (AP by BEV range from ego)',
+                  logger='current')
+        print_log('=' * 70, logger='current')
+
+        header = f'\n{"Class":<25} '
+        for bl in bin_labels:
+            header += f'{bl + " AP":<12} {bl + " GT":<10} '
+        header += f'{"Full AP":<10}'
+        print_log(header, logger='current')
+        print_log('-' * 80, logger='current')
+
+        any_printed = False
+        for cls_idx, cls_name in enumerate(self.classes):
+            # Count total GT in range for this class
+            total_gt_all = sum(
+                int((gt_labels == cls_idx).sum()) for gt_labels in all_gt_labels)
+            if total_gt_all < 10:
+                continue
+
+            row = f'{cls_name:<25} '
+            for bin_idx, (rmin, rmax) in enumerate(dist_bins):
+                bin_aps = []
+                bin_gt_count = 0
+                for dist_th in DIST_THRESHOLDS:
+                    ap, n_gt = self._eval_class_ap_range(
+                        all_dt_boxes, all_dt_scores, all_dt_labels,
+                        all_gt_boxes, all_gt_labels,
+                        cls_idx, dist_th, rmin, rmax)
+                    bin_aps.append(ap)
+                    bin_gt_count = n_gt
+
+                mean_bin_ap = float(np.mean(bin_aps))
+                ap_dict[f'{cls_name}/AP_{bin_labels[bin_idx]}'] = mean_bin_ap
+                ap_dict[f'{cls_name}/GT_{bin_labels[bin_idx]}'] = bin_gt_count
+
+                if bin_gt_count > 0:
+                    row += f'{mean_bin_ap:<12.4f} {bin_gt_count:<10} '
+                else:
+                    row += f'{"N/A":<12} {bin_gt_count:<10} '
+
+            # Full range AP (already computed, recompute for consistency)
+            full_aps = []
+            for dist_th in DIST_THRESHOLDS:
+                ap, _ = self._eval_class_ap_range(
+                    all_dt_boxes, all_dt_scores, all_dt_labels,
+                    all_gt_boxes, all_gt_labels,
+                    cls_idx, dist_th, 0, 50)
+                full_aps.append(ap)
+            full_ap = float(np.mean(full_aps))
+            row += f'{full_ap:<10.4f}'
+
+            print_log(row, logger='current')
+            any_printed = True
+
+        if not any_printed:
+            print_log('  (No classes with >= 10 GT objects in range)',
+                      logger='current')
+
+        print_log('-' * 80 + '\n', logger='current')
+        return ap_dict
+
+    def _eval_class_ap_range(self, all_dt_boxes, all_dt_scores, all_dt_labels,
+                             all_gt_boxes, all_gt_labels, class_id,
+                             dist_threshold, range_min, range_max):
+        """Compute AP for one class at one distance threshold, filtered by
+        BEV distance range.
+
+        Both GT and predictions are filtered to [range_min, range_max) BEV
+        distance from ego before matching.
+
+        Returns:
+            tuple: (ap, n_gt) where n_gt is GT count in this range.
+        """
+        all_scores = []
+        all_matches = []
+        total_gt = 0
+
+        for dt_boxes, dt_scores, dt_labels, gt_boxes, gt_labels in zip(
+                all_dt_boxes, all_dt_scores, all_dt_labels,
+                all_gt_boxes, all_gt_labels):
+
+            dt_mask = dt_labels == class_id
+            gt_mask = gt_labels == class_id
+
+            dt_cls_boxes = dt_boxes[dt_mask]
+            dt_cls_scores = dt_scores[dt_mask]
+            gt_cls_boxes = gt_boxes[gt_mask]
+
+            # Filter GT by BEV distance
+            if len(gt_cls_boxes) > 0:
+                gt_dists = np.sqrt(
+                    gt_cls_boxes[:, 0]**2 + gt_cls_boxes[:, 1]**2)
+                gt_range_mask = (gt_dists >= range_min) & (gt_dists < range_max)
+                gt_cls_boxes = gt_cls_boxes[gt_range_mask]
+
+            # Filter predictions by BEV distance
+            if len(dt_cls_boxes) > 0:
+                dt_dists = np.sqrt(
+                    dt_cls_boxes[:, 0]**2 + dt_cls_boxes[:, 1]**2)
+                dt_range_mask = (dt_dists >= range_min) & (dt_dists < range_max)
+                dt_cls_boxes = dt_cls_boxes[dt_range_mask]
+                dt_cls_scores = dt_cls_scores[dt_range_mask]
+
+            num_gt = len(gt_cls_boxes)
+            total_gt += num_gt
+
+            if len(dt_cls_boxes) == 0:
+                continue
+            if num_gt == 0:
+                all_scores.extend(dt_cls_scores.tolist())
+                all_matches.extend([False] * len(dt_cls_scores))
+                continue
+
+            dt_centers = dt_cls_boxes[:, :2]
+            gt_centers = gt_cls_boxes[:, :2]
+            dist_matrix = np.sqrt(
+                ((dt_centers[:, None, :] - gt_centers[None, :, :])**2).sum(-1))
+
+            sort_idx = np.argsort(-dt_cls_scores)
+            gt_matched = np.zeros(num_gt, dtype=bool)
+
+            for idx in sort_idx:
+                dists_masked = dist_matrix[idx].copy()
+                dists_masked[gt_matched] = np.inf
+                best_gt = np.argmin(dists_masked)
+
+                if dists_masked[best_gt] <= dist_threshold:
+                    gt_matched[best_gt] = True
+                    all_scores.append(dt_cls_scores[idx])
+                    all_matches.append(True)
+                else:
+                    all_scores.append(dt_cls_scores[idx])
+                    all_matches.append(False)
+
+        all_scores = np.array(all_scores) if all_scores else np.array([])
+        all_matches = np.array(all_matches, dtype=bool) if all_matches \
+            else np.array([], dtype=bool)
+
+        ap = accumulate_ap(all_scores, all_matches, total_gt)
+        return ap, total_gt
+
+    def _print_results(self, class_aps, class_tp_errors, mAP, mATE, mASE,
+                       mAOE, nds, nds_partial):
+        """Print results in nuScenes-style format."""
+        sep = '-' * 70
+        result_str = f'\n{sep}\n'
+        result_str += f'{"Object Class":<25} {"AP":<8} {"ATE":<8} {"ASE":<8} {"AOE":<8}\n'
+        result_str += f'{sep}\n'
+
+        for cls_idx, cls_name in enumerate(self.classes):
+            ap_str = f'{class_aps[cls_idx]:.4f}'
+            tp = class_tp_errors[cls_idx]
+            if tp is not None:
+                ate_str = f'{tp["ate"]:.4f}'
+                ase_str = f'{tp["ase"]:.4f}'
+                aoe_str = f'{tp["aoe"]:.4f}'
+            else:
+                ate_str = 'N/A'
+                ase_str = 'N/A'
+                aoe_str = 'N/A'
+            result_str += f'{cls_name:<25} {ap_str:<8} {ate_str:<8} {ase_str:<8} {aoe_str:<8}\n'
+
+        result_str += f'{sep}\n'
+        result_str += f'mAP:  {mAP:.4f}\n'
+        result_str += f'mATE: {mATE:.4f}\n'
+        result_str += f'mASE: {mASE:.4f}\n'
+        result_str += f'mAOE: {mAOE:.4f}\n'
+        result_str += f'mAVE: N/A (no velocity in PandaSet)\n'
+        result_str += f'mAAE: N/A (no attributes in PandaSet)\n'
+        result_str += f'NDS:  {nds:.4f} (with mAVE=1, mAAE=1)\n'
+        result_str += f'NDS (partial, 3 TP metrics only): {nds_partial:.4f}\n'
+        result_str += f'{sep}\n'
+
+        print_log(result_str, logger='current')

--- a/tools/convert_pandaset_to_bin_pcd.py
+++ b/tools/convert_pandaset_to_bin_pcd.py
@@ -2,29 +2,45 @@
 
 Converts world-frame point clouds to ego-centric frame and saves as:
   - .bin: raw float32 binary (x, y, z, intensity) per point
-  - .pcd: ASCII PCD format
+  - .pcd: binary PCD format (x, y, z, intensity)
 
 Output structure:
-  /swmotion-user-data/datasets/pandaset/cloud_bin/pandar64/{seq}/{frame}.bin
-  /swmotion-user-data/datasets/pandaset/cloud_bin/pandargt/{seq}/{frame}.bin
-  /swmotion-user-data/datasets/pandaset/cloud_pcd/pandar64/{seq}/{frame}.pcd
-  /swmotion-user-data/datasets/pandaset/cloud_pcd/pandargt/{seq}/{frame}.pcd
+  <out-dir>/cloud_bin/pandar64/{seq}/{frame}.bin
+  <out-dir>/cloud_bin/pandargt/{seq}/{frame}.bin
+  <out-dir>/cloud_pcd/pandar64/{seq}/{frame}.pcd
+  <out-dir>/cloud_pcd/pandargt/{seq}/{frame}.pcd
+
+Usage:
+    python tools/convert_pandaset_to_bin_pcd.py \
+        --pandaset-root data/pandaset/sequences \
+        --out-dir data/pandaset \
+        --workers 8
 """
 
-import os
+import argparse
 import json
+import os
 import pickle
+
 import numpy as np
-from pathlib import Path
 from multiprocessing import Pool
-from functools import partial
-
-
-PANDASET_ROOT = '/swmotion-user-data/datasets/pandaset/sequences'
-OUT_BIN = '/swmotion-user-data/datasets/pandaset/cloud_bin'
-OUT_PCD = '/swmotion-user-data/datasets/pandaset/cloud_pcd'
 
 SKIP_DIRS = {'pkls', 'cloud_bin', 'cloud_pcd'}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Convert PandaSet .pkl point clouds to .bin/.pcd')
+    parser.add_argument(
+        '--pandaset-root', required=True,
+        help='Path to pandaset sequences directory')
+    parser.add_argument(
+        '--out-dir', required=True,
+        help='Output directory (cloud_bin/ and cloud_pcd/ created inside)')
+    parser.add_argument(
+        '--workers', type=int, default=8,
+        help='Number of parallel workers')
+    return parser.parse_args()
 
 
 def pose_to_matrix(pose):
@@ -39,27 +55,8 @@ def pose_to_matrix(pose):
     return mat
 
 
-def write_pcd(filepath, points):
-    """Write points (N, 4) as ASCII PCD file."""
-    n = len(points)
-    with open(filepath, 'w') as f:
-        f.write("# .PCD v0.7 - Point Cloud Data file format\n")
-        f.write("VERSION 0.7\n")
-        f.write("FIELDS x y z intensity\n")
-        f.write("SIZE 4 4 4 4\n")
-        f.write("TYPE F F F F\n")
-        f.write("COUNT 1 1 1 1\n")
-        f.write(f"WIDTH {n}\n")
-        f.write("HEIGHT 1\n")
-        f.write("VIEWPOINT 0 0 0 1 0 0 0\n")
-        f.write(f"POINTS {n}\n")
-        f.write("DATA ascii\n")
-        for i in range(n):
-            f.write(f"{points[i,0]:.6f} {points[i,1]:.6f} {points[i,2]:.6f} {points[i,3]:.6f}\n")
-
-
 def write_pcd_binary(filepath, points):
-    """Write points (N, 4) as binary PCD file (much faster than ASCII)."""
+    """Write points (N, 4) as binary PCD file."""
     n = len(points)
     points_f32 = points.astype(np.float32)
     with open(filepath, 'wb') as f:
@@ -80,9 +77,10 @@ def write_pcd_binary(filepath, points):
         f.write(points_f32.tobytes())
 
 
-def process_sequence(seq_id):
+def process_sequence(args):
     """Process all frames in a sequence."""
-    seq_dir = os.path.join(PANDASET_ROOT, seq_id)
+    seq_id, pandaset_root, out_bin, out_pcd = args
+    seq_dir = os.path.join(pandaset_root, seq_id)
     lidar_dir = os.path.join(seq_dir, 'lidar')
     poses_file = os.path.join(lidar_dir, 'poses.json')
 
@@ -92,54 +90,47 @@ def process_sequence(seq_id):
     with open(poses_file, 'r') as f:
         poses = json.load(f)
 
-    frame_files = sorted([f for f in os.listdir(lidar_dir) if f.endswith('.pkl')])
+    frame_files = sorted([f for f in os.listdir(lidar_dir)
+                          if f.endswith('.pkl')])
     converted = 0
 
     for frame_file in frame_files:
         frame_idx = int(frame_file.replace('.pkl', ''))
         frame_path = os.path.join(lidar_dir, frame_file)
 
-        # Load point cloud
         with open(frame_path, 'rb') as f:
             df = pickle.load(f)
 
-        # Get pose and build inverse transform
         pose = poses[frame_idx]
         pose_mat = pose_to_matrix(pose)
         inv_pose = np.linalg.inv(pose_mat)
 
-        # Extract columns
         world_xyz = df[['x', 'y', 'z']].values.astype(np.float64)
         intensity = df['i'].values.astype(np.float32)
         device = df['d'].values  # 0=Pandar64, 1=PandarGT
 
-        # Transform to ego frame
         pts_h = np.hstack([world_xyz, np.ones((len(world_xyz), 1))])
         ego_xyz = (inv_pose @ pts_h.T).T[:, :3].astype(np.float32)
 
-        # Split by sensor
         mask_p64 = (device == 0)
         mask_pgt = (device == 1)
-
         frame_name = f'{frame_idx:02d}'
 
-        for sensor_name, mask in [('pandar64', mask_p64), ('pandargt', mask_pgt)]:
+        for sensor_name, mask in [('pandar64', mask_p64),
+                                  ('pandargt', mask_pgt)]:
             if mask.sum() == 0:
                 continue
 
-            pts = np.column_stack([ego_xyz[mask], intensity[mask]]).astype(np.float32)
+            pts = np.column_stack(
+                [ego_xyz[mask], intensity[mask]]).astype(np.float32)
 
-            # .bin output
-            bin_dir = os.path.join(OUT_BIN, sensor_name, seq_id)
+            bin_dir = os.path.join(out_bin, sensor_name, seq_id)
             os.makedirs(bin_dir, exist_ok=True)
-            bin_path = os.path.join(bin_dir, f'{frame_name}.bin')
-            pts.tofile(bin_path)
+            pts.tofile(os.path.join(bin_dir, f'{frame_name}.bin'))
 
-            # .pcd output
-            pcd_dir = os.path.join(OUT_PCD, sensor_name, seq_id)
+            pcd_dir = os.path.join(out_pcd, sensor_name, seq_id)
             os.makedirs(pcd_dir, exist_ok=True)
-            pcd_path = os.path.join(pcd_dir, f'{frame_name}.pcd')
-            write_pcd_binary(pcd_path, pts)
+            write_pcd_binary(os.path.join(pcd_dir, f'{frame_name}.pcd'), pts)
 
         converted += 1
 
@@ -147,27 +138,30 @@ def process_sequence(seq_id):
 
 
 def main():
-    # Get all sequence directories
-    all_entries = sorted(os.listdir(PANDASET_ROOT))
+    args = parse_args()
+    pandaset_root = args.pandaset_root
+    out_bin = os.path.join(args.out_dir, 'cloud_bin')
+    out_pcd = os.path.join(args.out_dir, 'cloud_pcd')
+
+    all_entries = sorted(os.listdir(pandaset_root))
     sequences = [e for e in all_entries if e not in SKIP_DIRS and
-                 os.path.isdir(os.path.join(PANDASET_ROOT, e, 'lidar'))]
+                 os.path.isdir(os.path.join(pandaset_root, e, 'lidar'))]
 
     print(f'Found {len(sequences)} sequences')
-    print(f'Output .bin: {OUT_BIN}')
-    print(f'Output .pcd: {OUT_PCD}')
+    print(f'Output .bin: {out_bin}')
+    print(f'Output .pcd: {out_pcd}')
     print()
 
-    # Process with multiprocessing
-    with Pool(processes=8) as pool:
-        results = pool.map(process_sequence, sequences)
+    pool_args = [(s, pandaset_root, out_bin, out_pcd) for s in sequences]
+    with Pool(processes=args.workers) as pool:
+        results = pool.map(process_sequence, pool_args)
 
     for r in results:
         print(r)
 
-    # Summary
     total_bin = 0
     for sensor in ['pandar64', 'pandargt']:
-        sensor_dir = os.path.join(OUT_BIN, sensor)
+        sensor_dir = os.path.join(out_bin, sensor)
         if os.path.exists(sensor_dir):
             for seq in os.listdir(sensor_dir):
                 seq_path = os.path.join(sensor_dir, seq)

--- a/tools/convert_pandaset_to_bin_pcd.py
+++ b/tools/convert_pandaset_to_bin_pcd.py
@@ -21,9 +21,9 @@ import argparse
 import json
 import os
 import pickle
+from multiprocessing import Pool
 
 import numpy as np
-from multiprocessing import Pool
 
 SKIP_DIRS = {'pkls', 'cloud_bin', 'cloud_pcd'}
 
@@ -32,14 +32,15 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description='Convert PandaSet .pkl point clouds to .bin/.pcd')
     parser.add_argument(
-        '--pandaset-root', required=True,
+        '--pandaset-root',
+        required=True,
         help='Path to pandaset sequences directory')
     parser.add_argument(
-        '--out-dir', required=True,
+        '--out-dir',
+        required=True,
         help='Output directory (cloud_bin/ and cloud_pcd/ created inside)')
     parser.add_argument(
-        '--workers', type=int, default=8,
-        help='Number of parallel workers')
+        '--workers', type=int, default=8, help='Number of parallel workers')
     return parser.parse_args()
 
 
@@ -60,19 +61,17 @@ def write_pcd_binary(filepath, points):
     n = len(points)
     points_f32 = points.astype(np.float32)
     with open(filepath, 'wb') as f:
-        header = (
-            "# .PCD v0.7 - Point Cloud Data file format\n"
-            "VERSION 0.7\n"
-            "FIELDS x y z intensity\n"
-            "SIZE 4 4 4 4\n"
-            "TYPE F F F F\n"
-            "COUNT 1 1 1 1\n"
-            f"WIDTH {n}\n"
-            "HEIGHT 1\n"
-            "VIEWPOINT 0 0 0 1 0 0 0\n"
-            f"POINTS {n}\n"
-            "DATA binary\n"
-        )
+        header = ('# .PCD v0.7 - Point Cloud Data file format\n'
+                  'VERSION 0.7\n'
+                  'FIELDS x y z intensity\n'
+                  'SIZE 4 4 4 4\n'
+                  'TYPE F F F F\n'
+                  'COUNT 1 1 1 1\n'
+                  f'WIDTH {n}\n'
+                  'HEIGHT 1\n'
+                  'VIEWPOINT 0 0 0 1 0 0 0\n'
+                  f'POINTS {n}\n'
+                  'DATA binary\n')
         f.write(header.encode('ascii'))
         f.write(points_f32.tobytes())
 
@@ -90,8 +89,8 @@ def process_sequence(args):
     with open(poses_file, 'r') as f:
         poses = json.load(f)
 
-    frame_files = sorted([f for f in os.listdir(lidar_dir)
-                          if f.endswith('.pkl')])
+    frame_files = sorted(
+        [f for f in os.listdir(lidar_dir) if f.endswith('.pkl')])
     converted = 0
 
     for frame_file in frame_files:
@@ -121,8 +120,8 @@ def process_sequence(args):
             if mask.sum() == 0:
                 continue
 
-            pts = np.column_stack(
-                [ego_xyz[mask], intensity[mask]]).astype(np.float32)
+            pts = np.column_stack([ego_xyz[mask],
+                                   intensity[mask]]).astype(np.float32)
 
             bin_dir = os.path.join(out_bin, sensor_name, seq_id)
             os.makedirs(bin_dir, exist_ok=True)
@@ -144,8 +143,10 @@ def main():
     out_pcd = os.path.join(args.out_dir, 'cloud_pcd')
 
     all_entries = sorted(os.listdir(pandaset_root))
-    sequences = [e for e in all_entries if e not in SKIP_DIRS and
-                 os.path.isdir(os.path.join(pandaset_root, e, 'lidar'))]
+    sequences = [
+        e for e in all_entries if e not in SKIP_DIRS
+        and os.path.isdir(os.path.join(pandaset_root, e, 'lidar'))
+    ]
 
     print(f'Found {len(sequences)} sequences')
     print(f'Output .bin: {out_bin}')

--- a/tools/convert_pandaset_to_bin_pcd.py
+++ b/tools/convert_pandaset_to_bin_pcd.py
@@ -1,0 +1,182 @@
+"""Convert PandaSet .pkl point clouds to .bin and .pcd formats.
+
+Converts world-frame point clouds to ego-centric frame and saves as:
+  - .bin: raw float32 binary (x, y, z, intensity) per point
+  - .pcd: ASCII PCD format
+
+Output structure:
+  /swmotion-user-data/datasets/pandaset/cloud_bin/pandar64/{seq}/{frame}.bin
+  /swmotion-user-data/datasets/pandaset/cloud_bin/pandargt/{seq}/{frame}.bin
+  /swmotion-user-data/datasets/pandaset/cloud_pcd/pandar64/{seq}/{frame}.pcd
+  /swmotion-user-data/datasets/pandaset/cloud_pcd/pandargt/{seq}/{frame}.pcd
+"""
+
+import os
+import json
+import pickle
+import numpy as np
+from pathlib import Path
+from multiprocessing import Pool
+from functools import partial
+
+
+PANDASET_ROOT = '/swmotion-user-data/datasets/pandaset/sequences'
+OUT_BIN = '/swmotion-user-data/datasets/pandaset/cloud_bin'
+OUT_PCD = '/swmotion-user-data/datasets/pandaset/cloud_pcd'
+
+SKIP_DIRS = {'pkls', 'cloud_bin', 'cloud_pcd'}
+
+
+def pose_to_matrix(pose):
+    """Convert pose dict (position + heading quaternion) to 4x4 matrix."""
+    from scipy.spatial.transform import Rotation as R
+    q = pose['heading']
+    rot = R.from_quat([q['x'], q['y'], q['z'], q['w']]).as_matrix()
+    mat = np.eye(4)
+    mat[:3, :3] = rot
+    pos = pose['position']
+    mat[:3, 3] = [pos['x'], pos['y'], pos['z']]
+    return mat
+
+
+def write_pcd(filepath, points):
+    """Write points (N, 4) as ASCII PCD file."""
+    n = len(points)
+    with open(filepath, 'w') as f:
+        f.write("# .PCD v0.7 - Point Cloud Data file format\n")
+        f.write("VERSION 0.7\n")
+        f.write("FIELDS x y z intensity\n")
+        f.write("SIZE 4 4 4 4\n")
+        f.write("TYPE F F F F\n")
+        f.write("COUNT 1 1 1 1\n")
+        f.write(f"WIDTH {n}\n")
+        f.write("HEIGHT 1\n")
+        f.write("VIEWPOINT 0 0 0 1 0 0 0\n")
+        f.write(f"POINTS {n}\n")
+        f.write("DATA ascii\n")
+        for i in range(n):
+            f.write(f"{points[i,0]:.6f} {points[i,1]:.6f} {points[i,2]:.6f} {points[i,3]:.6f}\n")
+
+
+def write_pcd_binary(filepath, points):
+    """Write points (N, 4) as binary PCD file (much faster than ASCII)."""
+    n = len(points)
+    points_f32 = points.astype(np.float32)
+    with open(filepath, 'wb') as f:
+        header = (
+            "# .PCD v0.7 - Point Cloud Data file format\n"
+            "VERSION 0.7\n"
+            "FIELDS x y z intensity\n"
+            "SIZE 4 4 4 4\n"
+            "TYPE F F F F\n"
+            "COUNT 1 1 1 1\n"
+            f"WIDTH {n}\n"
+            "HEIGHT 1\n"
+            "VIEWPOINT 0 0 0 1 0 0 0\n"
+            f"POINTS {n}\n"
+            "DATA binary\n"
+        )
+        f.write(header.encode('ascii'))
+        f.write(points_f32.tobytes())
+
+
+def process_sequence(seq_id):
+    """Process all frames in a sequence."""
+    seq_dir = os.path.join(PANDASET_ROOT, seq_id)
+    lidar_dir = os.path.join(seq_dir, 'lidar')
+    poses_file = os.path.join(lidar_dir, 'poses.json')
+
+    if not os.path.isfile(poses_file):
+        return f'{seq_id}: SKIP (no poses.json)'
+
+    with open(poses_file, 'r') as f:
+        poses = json.load(f)
+
+    frame_files = sorted([f for f in os.listdir(lidar_dir) if f.endswith('.pkl')])
+    converted = 0
+
+    for frame_file in frame_files:
+        frame_idx = int(frame_file.replace('.pkl', ''))
+        frame_path = os.path.join(lidar_dir, frame_file)
+
+        # Load point cloud
+        with open(frame_path, 'rb') as f:
+            df = pickle.load(f)
+
+        # Get pose and build inverse transform
+        pose = poses[frame_idx]
+        pose_mat = pose_to_matrix(pose)
+        inv_pose = np.linalg.inv(pose_mat)
+
+        # Extract columns
+        world_xyz = df[['x', 'y', 'z']].values.astype(np.float64)
+        intensity = df['i'].values.astype(np.float32)
+        device = df['d'].values  # 0=Pandar64, 1=PandarGT
+
+        # Transform to ego frame
+        pts_h = np.hstack([world_xyz, np.ones((len(world_xyz), 1))])
+        ego_xyz = (inv_pose @ pts_h.T).T[:, :3].astype(np.float32)
+
+        # Split by sensor
+        mask_p64 = (device == 0)
+        mask_pgt = (device == 1)
+
+        frame_name = f'{frame_idx:02d}'
+
+        for sensor_name, mask in [('pandar64', mask_p64), ('pandargt', mask_pgt)]:
+            if mask.sum() == 0:
+                continue
+
+            pts = np.column_stack([ego_xyz[mask], intensity[mask]]).astype(np.float32)
+
+            # .bin output
+            bin_dir = os.path.join(OUT_BIN, sensor_name, seq_id)
+            os.makedirs(bin_dir, exist_ok=True)
+            bin_path = os.path.join(bin_dir, f'{frame_name}.bin')
+            pts.tofile(bin_path)
+
+            # .pcd output
+            pcd_dir = os.path.join(OUT_PCD, sensor_name, seq_id)
+            os.makedirs(pcd_dir, exist_ok=True)
+            pcd_path = os.path.join(pcd_dir, f'{frame_name}.pcd')
+            write_pcd_binary(pcd_path, pts)
+
+        converted += 1
+
+    return f'{seq_id}: {converted} frames converted'
+
+
+def main():
+    # Get all sequence directories
+    all_entries = sorted(os.listdir(PANDASET_ROOT))
+    sequences = [e for e in all_entries if e not in SKIP_DIRS and
+                 os.path.isdir(os.path.join(PANDASET_ROOT, e, 'lidar'))]
+
+    print(f'Found {len(sequences)} sequences')
+    print(f'Output .bin: {OUT_BIN}')
+    print(f'Output .pcd: {OUT_PCD}')
+    print()
+
+    # Process with multiprocessing
+    with Pool(processes=8) as pool:
+        results = pool.map(process_sequence, sequences)
+
+    for r in results:
+        print(r)
+
+    # Summary
+    total_bin = 0
+    for sensor in ['pandar64', 'pandargt']:
+        sensor_dir = os.path.join(OUT_BIN, sensor)
+        if os.path.exists(sensor_dir):
+            for seq in os.listdir(sensor_dir):
+                seq_path = os.path.join(sensor_dir, seq)
+                if os.path.isdir(seq_path):
+                    total_bin += len(os.listdir(seq_path))
+
+    print(f'\nTotal .bin files: {total_bin}')
+    print('Done!')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/dataset_converters/pandaset_converter.py
+++ b/tools/dataset_converters/pandaset_converter.py
@@ -24,10 +24,9 @@ import numpy as np
 import pandas as pd
 from scipy.spatial.transform import Rotation
 
-NUSCENES_CLASSES = (
-    'car', 'truck', 'trailer', 'bus', 'construction_vehicle',
-    'bicycle', 'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'
-)
+NUSCENES_CLASSES = ('car', 'truck', 'trailer', 'bus', 'construction_vehicle',
+                    'bicycle', 'motorcycle', 'pedestrian', 'traffic_cone',
+                    'barrier')
 
 LABEL_MAP = {
     'Car': 'car',
@@ -54,7 +53,8 @@ def pose_to_matrix(pose_dict):
     """Convert PandaSet pose dict to 4x4 homogeneous matrix."""
     pos = pose_dict['position']
     heading = pose_dict['heading']
-    r = Rotation.from_quat([heading['x'], heading['y'], heading['z'], heading['w']])
+    r = Rotation.from_quat(
+        [heading['x'], heading['y'], heading['z'], heading['w']])
     mat = np.eye(4)
     mat[:3, :3] = r.as_matrix()
     mat[:3, 3] = [pos['x'], pos['y'], pos['z']]
@@ -70,7 +70,10 @@ def transform_box_to_ego(position, yaw, inv_pose, pose_yaw):
 
 
 def process_sequence(seq_id, pandaset_root):
-    """Process all frames of one sequence. Returns (list_64, list_gt)."""
+    """Process all frames of one sequence.
+
+    Returns (list_64, list_gt).
+    """
     seq_path = os.path.join(pandaset_root, seq_id)
     poses_file = os.path.join(seq_path, 'lidar', 'poses.json')
 
@@ -83,7 +86,8 @@ def process_sequence(seq_id, pandaset_root):
     lidar_dir = os.path.join(seq_path, 'lidar')
     cuboid_dir = os.path.join(seq_path, 'annotations', 'cuboids')
 
-    frame_files = sorted([f for f in os.listdir(lidar_dir) if f.endswith('.pkl')])
+    frame_files = sorted(
+        [f for f in os.listdir(lidar_dir) if f.endswith('.pkl')])
 
     results_64 = []
     results_gt = []
@@ -117,28 +121,37 @@ def process_sequence(seq_id, pandaset_root):
             nus_class = LABEL_MAP[label]
             class_idx = NUSCENES_CLASSES.index(nus_class)
 
-            position = np.array([row['position.x'], row['position.y'], row['position.z']])
+            position = np.array(
+                [row['position.x'], row['position.y'], row['position.z']])
             yaw = row['yaw']
             dim_l = row['dimensions.y']
             dim_w = row['dimensions.x']
             dim_h = row['dimensions.z']
 
-            ego_pos, ego_yaw = transform_box_to_ego(position, yaw, inv_pose, pose_yaw)
+            ego_pos, ego_yaw = transform_box_to_ego(position, yaw, inv_pose,
+                                                    pose_yaw)
 
             # Convention alignment:
-            # PandaSet: yaw=0 → length along Y. MMDet3D: yaw=0 → length along X.
+            # PandaSet: yaw=0 → length along Y.
+            # MMDet3D: yaw=0 → length along X.
             ego_yaw = ego_yaw + np.pi / 2
             # PandaSet: z = box center. nuScenes model: z = box bottom.
             ego_pos[2] = ego_pos[2] - dim_h / 2.0
 
             instances.append({
                 'bbox_3d': [
-                    float(ego_pos[0]), float(ego_pos[1]), float(ego_pos[2]),
-                    float(dim_l), float(dim_w), float(dim_h),
+                    float(ego_pos[0]),
+                    float(ego_pos[1]),
+                    float(ego_pos[2]),
+                    float(dim_l),
+                    float(dim_w),
+                    float(dim_h),
                     float(ego_yaw)
                 ],
-                'bbox_label_3d': class_idx,
-                'bbox_3d_isvalid': True,
+                'bbox_label_3d':
+                class_idx,
+                'bbox_3d_isvalid':
+                True,
             })
 
         sample_id = f'{seq_id}_{frame_idx:02d}'
@@ -201,18 +214,20 @@ def main():
 
     if args.workers > 1:
         with ProcessPoolExecutor(max_workers=args.workers) as executor:
-            futures = {executor.submit(_process_sequence_wrapper, t): t[0]
-                       for t in tasks}
+            futures = {
+                executor.submit(_process_sequence_wrapper, t): t[0]
+                for t in tasks
+            }
             done = 0
             for future in as_completed(futures):
                 done += 1
-                seq = futures[future]
                 r64, rgt = future.result()
                 all_64.extend(r64)
                 all_gt.extend(rgt)
                 if done % 10 == 0:
                     print(f'  Sequences done: {done}/{len(sequences)} '
-                          f'(frames so far: {len(all_64)} Pandar64, {len(all_gt)} PandarGT)')
+                          f'(frames so far: {len(all_64)} Pandar64, '
+                          f'{len(all_gt)} PandarGT)')
     else:
         for i, t in enumerate(tasks):
             r64, rgt = _process_sequence_wrapper(t)
@@ -224,7 +239,8 @@ def main():
     all_64.sort(key=lambda x: x['sample_idx'])
     all_gt.sort(key=lambda x: x['sample_idx'])
 
-    for data_list, name in [(all_64, 'pandaset_pandar64'), (all_gt, 'pandaset_pandargt')]:
+    for data_list, name in [(all_64, 'pandaset_pandar64'),
+                            (all_gt, 'pandaset_pandargt')]:
         info_pkl = {
             'metainfo': {
                 'CLASSES': NUSCENES_CLASSES,
@@ -243,7 +259,8 @@ def main():
         print(f'  Frames: {len(data_list)}')
         print(f'  Total instances: {total_inst}')
 
-    print('\nDone! Use LoadPointsFromPandaSet pipeline transform for inference.')
+    print('\nDone! Use LoadPointsFromPandaSet pipeline '
+          'transform for inference.')
 
 
 if __name__ == '__main__':

--- a/tools/dataset_converters/pandaset_converter.py
+++ b/tools/dataset_converters/pandaset_converter.py
@@ -1,0 +1,250 @@
+"""Convert PandaSet to MMDetection3D custom dataset format.
+
+Generates MMDetection3D v2 info pickle files for PandaSet. Processes both
+sensors in a single pass per frame to minimize I/O (reads each .pkl only once).
+
+Output:
+  - data/pandaset/pandaset_pandar64_infos_test.pkl
+  - data/pandaset/pandaset_pandargt_infos_test.pkl
+
+Usage:
+    python tools/dataset_converters/pandaset_converter.py \
+        --pandaset-root /swmotion-user-data/datasets/pandaset/sequences \
+        --out-dir data/pandaset \
+        --workers 8
+"""
+
+import argparse
+import json
+import os
+import pickle
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+import numpy as np
+import pandas as pd
+from scipy.spatial.transform import Rotation
+
+NUSCENES_CLASSES = (
+    'car', 'truck', 'trailer', 'bus', 'construction_vehicle',
+    'bicycle', 'motorcycle', 'pedestrian', 'traffic_cone', 'barrier'
+)
+
+LABEL_MAP = {
+    'Car': 'car',
+    'Pickup Truck': 'car',
+    'Medium-sized Truck': 'truck',
+    'Semi-truck': 'truck',
+    'Towed Object': 'trailer',
+    'Bus': 'bus',
+    'Tram / Subway': 'bus',
+    'Other Vehicle - Construction Vehicle': 'construction_vehicle',
+    'Bicycle': 'bicycle',
+    'Motorcycle': 'motorcycle',
+    'Motorized Scooter': 'motorcycle',
+    'Pedestrian': 'pedestrian',
+    'Pedestrian with Object': 'pedestrian',
+    'Cones': 'traffic_cone',
+    'Pylons': 'traffic_cone',
+    'Road Barriers': 'barrier',
+    'Temporary Construction Barriers': 'barrier',
+}
+
+
+def pose_to_matrix(pose_dict):
+    """Convert PandaSet pose dict to 4x4 homogeneous matrix."""
+    pos = pose_dict['position']
+    heading = pose_dict['heading']
+    r = Rotation.from_quat([heading['x'], heading['y'], heading['z'], heading['w']])
+    mat = np.eye(4)
+    mat[:3, :3] = r.as_matrix()
+    mat[:3, 3] = [pos['x'], pos['y'], pos['z']]
+    return mat
+
+
+def transform_box_to_ego(position, yaw, inv_pose, pose_yaw):
+    """Transform box center + yaw from world to ego frame."""
+    pos_h = np.array([position[0], position[1], position[2], 1.0])
+    ego_pos = (inv_pose @ pos_h)[:3]
+    ego_yaw = yaw - pose_yaw
+    return ego_pos, ego_yaw
+
+
+def process_sequence(seq_id, pandaset_root):
+    """Process all frames of one sequence. Returns (list_64, list_gt)."""
+    seq_path = os.path.join(pandaset_root, seq_id)
+    poses_file = os.path.join(seq_path, 'lidar', 'poses.json')
+
+    if not os.path.exists(poses_file):
+        return [], []
+
+    with open(poses_file) as f:
+        poses = json.load(f)
+
+    lidar_dir = os.path.join(seq_path, 'lidar')
+    cuboid_dir = os.path.join(seq_path, 'annotations', 'cuboids')
+
+    frame_files = sorted([f for f in os.listdir(lidar_dir) if f.endswith('.pkl')])
+
+    results_64 = []
+    results_gt = []
+
+    for fname in frame_files:
+        frame_idx = int(fname.replace('.pkl', ''))
+        lidar_file = os.path.join(lidar_dir, fname)
+        cuboid_file = os.path.join(cuboid_dir, fname)
+
+        if not os.path.exists(cuboid_file):
+            continue
+
+        pose_mat = pose_to_matrix(poses[frame_idx])
+        inv_pose = np.linalg.inv(pose_mat)
+        pose_yaw = Rotation.from_matrix(pose_mat[:3, :3]).as_euler('xyz')[2]
+
+        # Read lidar once, get counts for both sensors
+        lidar_df = pd.read_pickle(lidar_file)
+        counts = lidar_df['d'].value_counts()
+        num_pts_64 = int(counts.get(0, 0))
+        num_pts_gt = int(counts.get(1, 0))
+
+        # Read cuboids once, process annotations
+        cuboid_df = pd.read_pickle(cuboid_file)
+        instances = []
+        for _, row in cuboid_df.iterrows():
+            label = row['label']
+            if label not in LABEL_MAP:
+                continue
+
+            nus_class = LABEL_MAP[label]
+            class_idx = NUSCENES_CLASSES.index(nus_class)
+
+            position = np.array([row['position.x'], row['position.y'], row['position.z']])
+            yaw = row['yaw']
+            dim_l = row['dimensions.y']
+            dim_w = row['dimensions.x']
+            dim_h = row['dimensions.z']
+
+            ego_pos, ego_yaw = transform_box_to_ego(position, yaw, inv_pose, pose_yaw)
+
+            # Convention alignment:
+            # PandaSet: yaw=0 → length along Y. MMDet3D: yaw=0 → length along X.
+            ego_yaw = ego_yaw + np.pi / 2
+            # PandaSet: z = box center. nuScenes model: z = box bottom.
+            ego_pos[2] = ego_pos[2] - dim_h / 2.0
+
+            instances.append({
+                'bbox_3d': [
+                    float(ego_pos[0]), float(ego_pos[1]), float(ego_pos[2]),
+                    float(dim_l), float(dim_w), float(dim_h),
+                    float(ego_yaw)
+                ],
+                'bbox_label_3d': class_idx,
+                'bbox_3d_isvalid': True,
+            })
+
+        sample_id = f'{seq_id}_{frame_idx:02d}'
+        pose_list = pose_mat.tolist()
+
+        if num_pts_64 > 0:
+            results_64.append({
+                'lidar_points': {
+                    'lidar_path': lidar_file,
+                    'num_pts_feats': 4,
+                    'pandaset_sensor_id': 0,
+                    'pandaset_pose': pose_list,
+                },
+                'instances': instances,
+                'sample_idx': sample_id,
+                'num_pts': num_pts_64,
+            })
+
+        if num_pts_gt > 0:
+            results_gt.append({
+                'lidar_points': {
+                    'lidar_path': lidar_file,
+                    'num_pts_feats': 4,
+                    'pandaset_sensor_id': 1,
+                    'pandaset_pose': pose_list,
+                },
+                'instances': instances,
+                'sample_idx': sample_id,
+                'num_pts': num_pts_gt,
+            })
+
+    return results_64, results_gt
+
+
+def _process_sequence_wrapper(args):
+    return process_sequence(*args)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate PandaSet info pkls')
+    parser.add_argument('--pandaset-root', required=True)
+    parser.add_argument('--out-dir', required=True)
+    parser.add_argument('--workers', type=int, default=8)
+    args = parser.parse_args()
+
+    pandaset_root = args.pandaset_root
+    out_base = args.out_dir
+    os.makedirs(out_base, exist_ok=True)
+
+    sequences = sorted([
+        d for d in os.listdir(pandaset_root)
+        if os.path.isdir(os.path.join(pandaset_root, d))
+    ])
+    print(f'Found {len(sequences)} sequences in {pandaset_root}')
+
+    all_64 = []
+    all_gt = []
+
+    tasks = [(seq_id, pandaset_root) for seq_id in sequences]
+
+    if args.workers > 1:
+        with ProcessPoolExecutor(max_workers=args.workers) as executor:
+            futures = {executor.submit(_process_sequence_wrapper, t): t[0]
+                       for t in tasks}
+            done = 0
+            for future in as_completed(futures):
+                done += 1
+                seq = futures[future]
+                r64, rgt = future.result()
+                all_64.extend(r64)
+                all_gt.extend(rgt)
+                if done % 10 == 0:
+                    print(f'  Sequences done: {done}/{len(sequences)} '
+                          f'(frames so far: {len(all_64)} Pandar64, {len(all_gt)} PandarGT)')
+    else:
+        for i, t in enumerate(tasks):
+            r64, rgt = _process_sequence_wrapper(t)
+            all_64.extend(r64)
+            all_gt.extend(rgt)
+            if (i + 1) % 10 == 0:
+                print(f'  Sequences done: {i+1}/{len(sequences)}')
+
+    all_64.sort(key=lambda x: x['sample_idx'])
+    all_gt.sort(key=lambda x: x['sample_idx'])
+
+    for data_list, name in [(all_64, 'pandaset_pandar64'), (all_gt, 'pandaset_pandargt')]:
+        info_pkl = {
+            'metainfo': {
+                'CLASSES': NUSCENES_CLASSES,
+                'DATASET': name,
+                'pandaset_root': pandaset_root,
+            },
+            'data_list': data_list,
+        }
+        pkl_path = os.path.join(out_base, f'{name}_infos_test.pkl')
+        with open(pkl_path, 'wb') as f:
+            pickle.dump(info_pkl, f, protocol=2)
+
+        total_inst = sum(len(d['instances']) for d in data_list)
+        print(f'\n{name}:')
+        print(f'  File: {pkl_path}')
+        print(f'  Frames: {len(data_list)}')
+        print(f'  Total instances: {total_inst}')
+
+    print('\nDone! Use LoadPointsFromPandaSet pipeline transform for inference.')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/dataset_converters/pandaset_converter.py
+++ b/tools/dataset_converters/pandaset_converter.py
@@ -9,7 +9,7 @@ Output:
 
 Usage:
     python tools/dataset_converters/pandaset_converter.py \
-        --pandaset-root /swmotion-user-data/datasets/pandaset/sequences \
+        --pandaset-root data/pandaset/sequences \
         --out-dir data/pandaset \
         --workers 8
 """


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

MMDetection3D currently lacks support for the PandaSet dataset, which is a valuable autonomous driving dataset featuring a dual-LiDAR system (Hesai Pandar64 + PandarGT). PandaSet enables cross-dataset generalization testing — evaluating models trained on one dataset (e.g., nuScenes) against data from different LiDAR sensors. This is critical for developing robust LiDAR perception algorithms that generalize beyond their training distribution.

## Modification

Adds full PandaSet dataset support for 3D object detection:

- `mmdet3d/datasets/pandaset_dataset.py` — PandaSetDataset class with nuScenes 10-class label mapping
- `mmdet3d/datasets/transforms/pandaset_loading.py` — LoadPointsFromPandaSet transform (world-to-ego on-the-fly) + NormalizePointsIntensity
- `mmdet3d/evaluation/metrics/pandaset_metric.py` — nuScenes-style metric (center-distance AP, mATE, mASE, mAOE, NDS)
- `tools/dataset_converters/pandaset_converter.py` — Info pkl generator with dual-LiDAR split
- `tools/convert_pandaset_to_bin_pcd.py` — Optional .bin/.pcd pre-conversion tool
- `configs/_base_/datasets/pandaset-3d.py` — Base dataset config
- `configs/pointpillars/*pandaset*.py` — Evaluation configs for Pandar64 and PandarGT
- `docs/en/advanced_guides/datasets/pandaset.md` — Full documentation

Cross-dataset results (nuScenes PointPillars FPN → PandaSet Pandar64):

| Metric | Value |
|--------|-------|
| mAP | 0.072 |
| Car AP | 0.47 |
| Pedestrian AP | 0.21 |
| Car AP (0-25m) | 0.72 |

## BC-breaking (Optional)

No. This PR only adds new files and extends `__init__.py` imports. No existing code is modified in a breaking way.

## Use cases (Optional)

**1. Cross-dataset generalization testing** — Evaluate any nuScenes-trained 3D detector on PandaSet to measure sensor generalization:
```bash
python tools/test.py \
    configs/pointpillars/pointpillars_hv_fpn_sbn-all_8xb4-2x_pandaset-eval.py \
    checkpoints/hv_pointpillars_fpn_sbn-all_4x8_2x_nus-3d.pth
```
**2. Dual-LiDAR comparison** — Compare model performance on 360 degree spinning LiDAR (Pandar64) vs forward-facing solid-state LiDAR (PandarGT)
**3. Distance-based analysis** — Built-in distance-bin evaluation (0-25m, 25-50m) shows near-range vs far-range performance automatically
## Checklist
- [x] Code follows existing MMDetection3D style and conventions
- [ ] Unit tests (to be added if requested by maintainers)
- [x] No impact on downstream projects — purely additive
- [x] Documentation added at docs/en/advanced_guides/datasets/pandaset.md
